### PR TITLE
Multiple XML record emitters

### DIFF
--- a/src/main/java/com/karbherin/flatterxml/FlattenXml.java
+++ b/src/main/java/com/karbherin/flatterxml/FlattenXml.java
@@ -261,6 +261,10 @@ public class FlattenXml {
         XMLEvent ev;
         Deque<Pair<QName, String>> pairStack = new ArrayDeque<>();
 
+        if (tagStack.isEmpty()) {
+            return;
+        }
+
         // Read one part of an XML element at a time.
         while (!(ev = tagStack.pop()).isStartElement()) {
 
@@ -386,7 +390,7 @@ public class FlattenXml {
 
     private XMLStreamException decorateParseError(XMLStreamException ex) throws IOException {
         Deque<XMLEvent> errorRec = new ArrayDeque<>();
-        // writeRecord(errorRec);
+        writeRecord(errorRec);
         javax.xml.stream.Location loc = ex.getLocation();
         ex.initCause(new XMLStreamException("Excerpt of text before the error location:\n"+
                 XmlHelpers.eventsRecordToString(errorRec) +

--- a/src/main/java/com/karbherin/flatterxml/FlattenXml.java
+++ b/src/main/java/com/karbherin/flatterxml/FlattenXml.java
@@ -386,7 +386,7 @@ public class FlattenXml {
 
     private XMLStreamException decorateParseError(XMLStreamException ex) throws IOException {
         Deque<XMLEvent> errorRec = new ArrayDeque<>();
-        writeRecord(errorRec);
+        // writeRecord(errorRec);
         javax.xml.stream.Location loc = ex.getLocation();
         ex.initCause(new XMLStreamException("Excerpt of text before the error location:\n"+
                 XmlHelpers.eventsRecordToString(errorRec) +

--- a/src/main/java/com/karbherin/flatterxml/FlattenXmlRunner.java
+++ b/src/main/java/com/karbherin/flatterxml/FlattenXmlRunner.java
@@ -35,6 +35,7 @@ public class FlattenXmlRunner {
     private static final String INDENT = "  ";
     private static final HelpFormatter HELP_FORMATTER = new HelpFormatter();
     private static final String ENV_BYTE_STREAM_EMITTER = "BYTE_STREAM_EMITTER";
+    private static final int EMITTER_LOAD_FACTOR = 4;
 
     private final Options options = new Options();
     private final FlattenXml.FlattenXmlBuilder setup;
@@ -227,8 +228,8 @@ public class FlattenXmlRunner {
         if (System.getenv(ENV_BYTE_STREAM_EMITTER) != null) {
             System.out.println("Employing XML byte stream for dispatching to workers");
             int numProducers = 1;
-            if (numWorkers / 4 > 1) {
-                numProducers = numWorkers / 4;
+            if (numWorkers / EMITTER_LOAD_FACTOR > 1) {
+                numProducers = numWorkers / EMITTER_LOAD_FACTOR;
                 System.out.printf("Using %d parallel stream emitters%n", numProducers);
             }
 

--- a/src/main/java/com/karbherin/flatterxml/FlattenXmlRunner.java
+++ b/src/main/java/com/karbherin/flatterxml/FlattenXmlRunner.java
@@ -5,7 +5,7 @@ import com.karbherin.flatterxml.consumer.XmlEventWorkerPool;
 import com.karbherin.flatterxml.consumer.XmlFlattenerWorkerFactory;
 import com.karbherin.flatterxml.feeder.XmlEventEmitter;
 import com.karbherin.flatterxml.feeder.XmlRecordEmitter;
-import com.karbherin.flatterxml.helper.XmlHelpers;
+import static com.karbherin.flatterxml.helper.XmlHelpers.*;
 import com.karbherin.flatterxml.output.DelimitedFileHandler;
 import com.karbherin.flatterxml.output.RecordHandler;
 import com.karbherin.flatterxml.output.StatusReporter;
@@ -54,7 +54,7 @@ public class FlattenXmlRunner {
     private CommandLine cmd;
 
     private Collection<String[]> filesGenerated = Collections.emptyList();
-    private String rootTagName = XmlHelpers.EMPTY;
+    private String rootTagName = EMPTY;
 
     // Track status and progress
     private final StatusReporter statusReporter = new StatusReporter();
@@ -141,7 +141,7 @@ public class FlattenXmlRunner {
 
         if (cmd.hasOption("x")) {
             String[] xmlFiles = cmd.getOptionValue("x").split(",");
-            xsds = XmlHelpers.parseXsds(xmlFiles);
+            xsds = parseXsds(xmlFiles);
         }
 
         try {
@@ -201,7 +201,7 @@ public class FlattenXmlRunner {
             if (firstLoop && recordTag == null) {
                 firstLoop = false;
                 System.out.printf("Starting record tag not provided.\nIdentified primary record tag '%s'%n",
-                        XmlHelpers.toPrefixedTag(flattener.getRecordTag()));
+                        toPrefixedTag(flattener.getRecordTag()));
             }
 
             statusReporter.showProgress();
@@ -231,8 +231,9 @@ public class FlattenXmlRunner {
             int numProducers = 1;
 
             if (System.getenv(ENV_BYTE_STREAM_MULTI_EMITTER) != null) {
-                if (numWorkers / EMITTER_LOAD_FACTOR > 1) {
-                    numProducers = numWorkers / EMITTER_LOAD_FACTOR;
+                int loadFactor = parseInt(ENV_BYTE_STREAM_MULTI_EMITTER, EMITTER_LOAD_FACTOR);
+                if (numWorkers / loadFactor > 1) {
+                    numProducers = numWorkers / loadFactor;
                     System.out.printf("Using %d parallel XML byte stream emitters%n", numProducers);
                 }
             }
@@ -262,7 +263,7 @@ public class FlattenXmlRunner {
         System.out.println();
         if (recordTag == null) {
             System.out.printf("Starting record tag not provided.\nIdentified primary record tag '%s'%n",
-                    XmlHelpers.toPrefixedTag(emitter.getRecordTag()));
+                    toPrefixedTag(emitter.getRecordTag()));
         }
 
         filesGenerated = statusReporter.getFilesGenerated();

--- a/src/main/java/com/karbherin/flatterxml/FlattenXmlRunner.java
+++ b/src/main/java/com/karbherin/flatterxml/FlattenXmlRunner.java
@@ -231,7 +231,7 @@ public class FlattenXmlRunner {
             int numProducers = 1;
 
             if (System.getenv(ENV_BYTE_STREAM_MULTI_EMITTER) != null) {
-                int loadFactor = parseInt(ENV_BYTE_STREAM_MULTI_EMITTER, EMITTER_LOAD_FACTOR);
+                int loadFactor = parseInt(System.getenv(ENV_BYTE_STREAM_MULTI_EMITTER), EMITTER_LOAD_FACTOR);
                 if (numWorkers / loadFactor > 1) {
                     numProducers = numWorkers / loadFactor;
                     System.out.printf("Using %d parallel XML byte stream emitters%n", numProducers);

--- a/src/main/java/com/karbherin/flatterxml/FlattenXmlRunner.java
+++ b/src/main/java/com/karbherin/flatterxml/FlattenXmlRunner.java
@@ -1,9 +1,9 @@
 package com.karbherin.flatterxml;
 
 import com.karbherin.flatterxml.feeder.XmlByteStreamEmitter;
-import com.karbherin.flatterxml.feeder.XmlEventEmitter;
 import com.karbherin.flatterxml.consumer.XmlEventWorkerPool;
 import com.karbherin.flatterxml.consumer.XmlFlattenerWorkerFactory;
+import com.karbherin.flatterxml.feeder.XmlEventEmitter;
 import com.karbherin.flatterxml.feeder.XmlRecordEmitter;
 import com.karbherin.flatterxml.helper.XmlHelpers;
 import com.karbherin.flatterxml.output.DelimitedFileHandler;
@@ -226,10 +226,21 @@ public class FlattenXmlRunner {
         XmlRecordEmitter emitter;
         if (System.getenv(ENV_BYTE_STREAM_EMITTER) != null) {
             System.out.println("Employing XML byte stream for dispatching to workers");
-            emitter = new XmlByteStreamEmitter(xmlFilePath);
+            int numProducers = 1;
+            if (numWorkers / 4 > 1) {
+                numProducers = numWorkers / 4;
+                System.out.printf("Using %d parallel stream emitters%n", numProducers);
+            }
+
+            emitter = new XmlByteStreamEmitter.XmlByteStreamEmitterBuilder()
+                    .setXmlFile(xmlFilePath)
+                    .setNumProducers(numProducers)
+                    .create();
         } else {
             System.out.println("Employing XML event stream for dispatching to workers");
-            emitter = new XmlEventEmitter(xmlFilePath);
+            emitter = new XmlEventEmitter.XmlEventEmitterBuilder()
+                    .setXmlFile(xmlFilePath)
+                    .create();
         }
         XmlFlattenerWorkerFactory workerFactory = XmlFlattenerWorkerFactory.newInstance(
                 xmlFilePath, outDir, delimiter, recordTag, recordHandler,

--- a/src/main/java/com/karbherin/flatterxml/FlattenXmlRunner.java
+++ b/src/main/java/com/karbherin/flatterxml/FlattenXmlRunner.java
@@ -35,6 +35,7 @@ public class FlattenXmlRunner {
     private static final String INDENT = "  ";
     private static final HelpFormatter HELP_FORMATTER = new HelpFormatter();
     private static final String ENV_BYTE_STREAM_EMITTER = "BYTE_STREAM_EMITTER";
+    private static final String ENV_BYTE_STREAM_MULTI_EMITTER = "BYTE_STREAM_MULTI_EMITTER";
     private static final int EMITTER_LOAD_FACTOR = 4;
 
     private final Options options = new Options();
@@ -228,9 +229,12 @@ public class FlattenXmlRunner {
         if (System.getenv(ENV_BYTE_STREAM_EMITTER) != null) {
             System.out.println("Employing XML byte stream for dispatching to workers");
             int numProducers = 1;
-            if (numWorkers / EMITTER_LOAD_FACTOR > 1) {
-                numProducers = numWorkers / EMITTER_LOAD_FACTOR;
-                System.out.printf("Using %d parallel stream emitters%n", numProducers);
+
+            if (System.getenv(ENV_BYTE_STREAM_MULTI_EMITTER) != null) {
+                if (numWorkers / EMITTER_LOAD_FACTOR > 1) {
+                    numProducers = numWorkers / EMITTER_LOAD_FACTOR;
+                    System.out.printf("Using %d parallel XML byte stream emitters%n", numProducers);
+                }
             }
 
             emitter = new XmlByteStreamEmitter.XmlByteStreamEmitterBuilder()
@@ -243,6 +247,7 @@ public class FlattenXmlRunner {
                     .setXmlFile(xmlFilePath)
                     .create();
         }
+
         XmlFlattenerWorkerFactory workerFactory = XmlFlattenerWorkerFactory.newInstance(
                 xmlFilePath, outDir, delimiter, recordTag, recordHandler,
                 cascadePolicy, xsds, recordCascadeFieldsDefFile, recordOutputFieldsDefFile,

--- a/src/main/java/com/karbherin/flatterxml/XmlFileSplitterRunner.java
+++ b/src/main/java/com/karbherin/flatterxml/XmlFileSplitterRunner.java
@@ -59,7 +59,8 @@ public class XmlFileSplitterRunner {
         XmlEventWorkerPool workerPool = new XmlEventWorkerPool();
         XmlFileSplitterFactory workerFactory = XmlFileSplitterFactory.newInstance(outDir, xmlFilePath);
 
-        workerPool.execute(numSplits, new XmlByteStreamEmitter(xmlFilePath), workerFactory);
+        workerPool.execute(numSplits, new XmlByteStreamEmitter.XmlByteStreamEmitterBuilder()
+                .setXmlFile(xmlFilePath).create(), workerFactory);
 
         Long[] recCountsBySplit = workerFactory.getRecordsCount();
         for (int splitNum = 0; splitNum < recCountsBySplit.length; splitNum++) {

--- a/src/main/java/com/karbherin/flatterxml/feeder/XmlEventEmitter.java
+++ b/src/main/java/com/karbherin/flatterxml/feeder/XmlEventEmitter.java
@@ -35,31 +35,11 @@ public class XmlEventEmitter implements XmlRecordEmitter {
      * @throws IOException
      * @throws XMLStreamException
      */
-    public XmlEventEmitter(String xmlFile, long skipRecs, long firstNRecs) {
+    private XmlEventEmitter(String xmlFile, long skipRecs, long firstNRecs) {
         this.xmlFile = xmlFile;
         this.skipRecs = skipRecs;
         this.firstNRecs = firstNRecs;
     }
-
-    /**
-     * Start events feed. The entire XML file is processed.
-     * @throws XMLStreamException
-     * @throws IOException
-     */
-    public XmlEventEmitter(String xmlFile) {
-        this(xmlFile, 0, Long.MAX_VALUE);
-    }
-
-    /**
-     * Start events feed after skipping a few records.
-     * @param skipRecs - 0 disables skipping records
-     * @throws XMLStreamException
-     * @throws IOException
-     */
-    public XmlEventEmitter(String xmlFile, long skipRecs) {
-        this(xmlFile, skipRecs, Long.MAX_VALUE);
-    }
-
 
     /**
      * Register a pipe to an events worker.
@@ -201,6 +181,31 @@ public class XmlEventEmitter implements XmlRecordEmitter {
     private void sendToAllChannels(XMLEvent ev) throws XMLStreamException {
         for (XMLEventWriter channel: channels) {
             channel.add(ev);
+        }
+    }
+
+    public static class XmlEventEmitterBuilder {
+        private String xmlFile;
+        private long skipRecs = 0;
+        private long firstNRecs = Long.MAX_VALUE;
+
+        public XmlEventEmitterBuilder setXmlFile(String xmlFile) {
+            this.xmlFile = xmlFile;
+            return this;
+        }
+
+        public XmlEventEmitterBuilder setSkipRecs(long skipRecs) {
+            this.skipRecs = skipRecs;
+            return this;
+        }
+
+        public XmlEventEmitterBuilder setFirstNRecs(long firstNRecs) {
+            this.firstNRecs = firstNRecs;
+            return this;
+        }
+
+        public XmlEventEmitter create() {
+            return new XmlEventEmitter(xmlFile, skipRecs, firstNRecs);
         }
     }
 

--- a/src/main/java/com/karbherin/flatterxml/feeder/XmlScanner.java
+++ b/src/main/java/com/karbherin/flatterxml/feeder/XmlScanner.java
@@ -57,7 +57,7 @@ public class XmlScanner {
      * @throws IOException
      */
     public String next() throws IOException {
-        buffer.rewind();
+        buffer.clear();
 
         // Calculate buffer size based on read boundary
         int bufferSize = (int) Math.min(bytesReadLimit - bytesRead - extendRead, buffer.capacity());

--- a/src/main/java/com/karbherin/flatterxml/feeder/XmlScanner.java
+++ b/src/main/java/com/karbherin/flatterxml/feeder/XmlScanner.java
@@ -120,7 +120,7 @@ public class XmlScanner {
      * @param
      * @throws IOException
      */
-    public XmlScanner sendToAllChannels() throws IOException {
+    public XmlScanner sendToAllChannels(List<? extends WritableByteChannel> channels) throws IOException {
         for (WritableByteChannel channel : channels) {
             composeBuffer.flip();
             channel.write(composeBuffer);

--- a/src/main/java/com/karbherin/flatterxml/helper/XmlHelpers.java
+++ b/src/main/java/com/karbherin/flatterxml/helper/XmlHelpers.java
@@ -197,4 +197,12 @@ public class XmlHelpers {
         return defaultIfNull(str, EMPTY);
     }
 
+    public static int parseInt(String str, int defaultValue) {
+        try {
+            return Integer.valueOf(str);
+        } catch (NumberFormatException ex) {
+            return defaultValue;
+        }
+    }
+
 }

--- a/src/test/java/com/karbherin/flatterxml/feeder/XmlByteStreamEmitterTest.java
+++ b/src/test/java/com/karbherin/flatterxml/feeder/XmlByteStreamEmitterTest.java
@@ -53,14 +53,19 @@ public class XmlByteStreamEmitterTest {
                 workerPool.execute(1, new XmlByteStreamEmitterBuilder().setXmlFile(xmlFilePath).create(),
                         new XmlPipeToFileWriter(outDir, "emp_bytestream.xml")));
         assertEquals("Skip 5 records", 16,
-                workerPool.execute(3, new XmlByteStreamEmitter(xmlFilePath, 5), workerFactory));
+                workerPool.execute(3, new XmlByteStreamEmitter.XmlByteStreamEmitterBuilder().setXmlFile(xmlFilePath)
+                        .setSkipRecs(5).create(), workerFactory));
         assertEquals("Skip 5 records", 16,
-                workerPool.execute(3, new XmlByteStreamEmitter(xmlFilePath, 5), workerFactory));
+                workerPool.execute(3, new XmlByteStreamEmitter.XmlByteStreamEmitterBuilder().setXmlFile(xmlFilePath)
+                        .setSkipRecs(5).create(), workerFactory));
         assertEquals("Skip 5 and pick first 4", 4,
-                workerPool.execute(3, new XmlByteStreamEmitter(xmlFilePath, 5, 4), workerFactory));
+                workerPool.execute(3, new XmlByteStreamEmitter.XmlByteStreamEmitterBuilder().setXmlFile(xmlFilePath)
+                        .setSkipRecs(5).setFirstNRecs(4).create(), workerFactory));
         assertEquals("First 4 records", 4,
-                workerPool.execute(3, new XmlByteStreamEmitter(xmlFilePath, 0, 4), workerFactory));
-        XmlRecordEmitter emitter = new XmlByteStreamEmitter(xmlFilePath, 18, 10);
+                workerPool.execute(3, new XmlByteStreamEmitter.XmlByteStreamEmitterBuilder().setXmlFile(xmlFilePath)
+                        .setSkipRecs(0).setFirstNRecs(4).create(), workerFactory));
+        XmlRecordEmitter emitter = new XmlByteStreamEmitter.XmlByteStreamEmitterBuilder().setXmlFile(xmlFilePath)
+                .setSkipRecs(18).setFirstNRecs(10).create();
         assertEquals("Overshoot the end", 3,
                 workerPool.execute(3, emitter, workerFactory));
 
@@ -72,7 +77,8 @@ public class XmlByteStreamEmitterTest {
     public void splitterNSXml_test() throws IOException, XMLStreamException, InterruptedException {
         String xmlFilePath = "src/test/resources/emp.xml";
         String outDir = "target/test/resources/emp_tables/splits";
-        XmlRecordEmitter emitter = new XmlByteStreamEmitter("src/test/resources/emp_ns.xml", 1, 10);
+        XmlRecordEmitter emitter = new XmlByteStreamEmitter.XmlByteStreamEmitterBuilder()
+                .setXmlFile("src/test/resources/emp_ns.xml").setSkipRecs(1).setFirstNRecs(10).create();
         XmlFileSplitterFactory workerFactory = XmlFileSplitterFactory.newInstance(outDir, xmlFilePath);
         XmlEventWorkerPool workerPool = new XmlEventWorkerPool();
         assertEquals("Overshoot the end", 2,

--- a/src/test/java/com/karbherin/flatterxml/feeder/XmlEventEmitterTest.java
+++ b/src/test/java/com/karbherin/flatterxml/feeder/XmlEventEmitterTest.java
@@ -14,11 +14,21 @@ public class XmlEventEmitterTest {
     @Test
     public void test() throws IOException, XMLStreamException, InterruptedException {
         String xmlFile = "src/test/resources/emp.xml";
-        Assert.assertEquals("Entire file", 21, run(new XmlEventEmitter(xmlFile)));
-        Assert.assertEquals("Skip 5 records", 16, run(new XmlEventEmitter(xmlFile, 5)));
-        Assert.assertEquals("Skip 5 and pick first 4", 4, run(new XmlEventEmitter(xmlFile, 5, 4)));
-        Assert.assertEquals("First 4 records", 4, run(new XmlEventEmitter(xmlFile, 0, 4)));
-        Assert.assertEquals("Overshoot the end", 3, run(new XmlEventEmitter(xmlFile, 18, 10)));
+        Assert.assertEquals("Entire file", 21, run(
+                new XmlEventEmitter.XmlEventEmitterBuilder()
+                .setXmlFile(xmlFile).create()));
+        Assert.assertEquals("Skip 5 records", 16, run(
+                new XmlEventEmitter.XmlEventEmitterBuilder()
+                .setXmlFile(xmlFile).setSkipRecs(5).create()));
+        Assert.assertEquals("Skip 5 and pick first 4", 4, run(
+                new XmlEventEmitter.XmlEventEmitterBuilder()
+                .setXmlFile(xmlFile).setSkipRecs(5).setFirstNRecs(4).create()));
+        Assert.assertEquals("First 4 records", 4, run(
+                new XmlEventEmitter.XmlEventEmitterBuilder()
+                .setXmlFile(xmlFile).setSkipRecs(0).setFirstNRecs(4).create()));
+        Assert.assertEquals("Overshoot the end", 3, run(
+                new XmlEventEmitter.XmlEventEmitterBuilder()
+                .setXmlFile(xmlFile).setSkipRecs(18).setFirstNRecs(10).create()));
     }
     private long run(XmlEventEmitter emitter)
             throws IOException, XMLStreamException, InterruptedException {

--- a/src/test/java/com/karbherin/flatterxml/feeder/XmlFileSplitterTest.java
+++ b/src/test/java/com/karbherin/flatterxml/feeder/XmlFileSplitterTest.java
@@ -18,15 +18,20 @@ public class XmlFileSplitterTest {
         XmlFileSplitterFactory workerFactory = XmlFileSplitterFactory.newInstance(outDir, xmlFilePath);
 
         Assert.assertEquals("Entire file", 21,
-                workerPool.execute(3, new XmlEventEmitter(xmlFilePath), workerFactory));
+                workerPool.execute(3, new XmlEventEmitter.XmlEventEmitterBuilder()
+                        .setXmlFile(xmlFilePath).create(), workerFactory));
         Assert.assertEquals("Skip 5 records", 16,
-                workerPool.execute(3, new XmlEventEmitter(xmlFilePath, 5), workerFactory));
+                workerPool.execute(3, new XmlEventEmitter.XmlEventEmitterBuilder()
+                        .setXmlFile(xmlFilePath).setSkipRecs(5).create(), workerFactory));
         Assert.assertEquals("Skip 5 and pick first 4", 4,
-                workerPool.execute(3, new XmlEventEmitter(xmlFilePath, 5, 4), workerFactory));
+                workerPool.execute(3, new XmlEventEmitter.XmlEventEmitterBuilder()
+                        .setXmlFile(xmlFilePath).setSkipRecs(5).setFirstNRecs(4).create(), workerFactory));
         Assert.assertEquals("First 4 records", 4,
-                workerPool.execute(3, new XmlEventEmitter(xmlFilePath, 0, 4), workerFactory));
+                workerPool.execute(3, new XmlEventEmitter.XmlEventEmitterBuilder()
+                        .setXmlFile(xmlFilePath).setSkipRecs(0).setFirstNRecs(4).create(), workerFactory));
         Assert.assertEquals("Overshoot the end", 3,
-                workerPool.execute(3, new XmlEventEmitter(xmlFilePath, 18, 10), workerFactory));
+                workerPool.execute(3, new XmlEventEmitter.XmlEventEmitterBuilder()
+                        .setXmlFile(xmlFilePath).setSkipRecs(18).setFirstNRecs(10).create(), workerFactory));
     }
 
     @Test
@@ -37,14 +42,19 @@ public class XmlFileSplitterTest {
         XmlFileSplitterFactory workerFactory = XmlFileSplitterFactory.newInstance(outDir, xmlFilePath);
 
         Assert.assertEquals("Entire file", 21,
-                workerPool.execute(3, new XmlByteStreamEmitter(xmlFilePath), workerFactory));
+                workerPool.execute(3, new XmlByteStreamEmitter.XmlByteStreamEmitterBuilder()
+                        .setXmlFile(xmlFilePath).create(), workerFactory));
         Assert.assertEquals("Skip 5 records", 16,
-                workerPool.execute(3, new XmlByteStreamEmitter(xmlFilePath, 5), workerFactory));
+                workerPool.execute(3, new XmlByteStreamEmitter.XmlByteStreamEmitterBuilder()
+                        .setXmlFile(xmlFilePath).setSkipRecs(5).create(), workerFactory));
         Assert.assertEquals("Skip 5 and pick first 4", 4,
-                workerPool.execute(3, new XmlByteStreamEmitter(xmlFilePath, 5, 4), workerFactory));
+                workerPool.execute(3, new XmlByteStreamEmitter.XmlByteStreamEmitterBuilder()
+                        .setXmlFile(xmlFilePath).setSkipRecs(5).setFirstNRecs(4).create(), workerFactory));
         Assert.assertEquals("First 4 records", 4,
-                workerPool.execute(3, new XmlByteStreamEmitter(xmlFilePath, 0, 4), workerFactory));
+                workerPool.execute(3, new XmlByteStreamEmitter.XmlByteStreamEmitterBuilder()
+                        .setXmlFile(xmlFilePath).setSkipRecs(0).setFirstNRecs(4).create(), workerFactory));
         Assert.assertEquals("Overshoot the end", 3,
-                workerPool.execute(3, new XmlByteStreamEmitter(xmlFilePath, 18, 10), workerFactory));
+                workerPool.execute(3, new XmlByteStreamEmitter.XmlByteStreamEmitterBuilder()
+                        .setXmlFile(xmlFilePath).setSkipRecs(18).setFirstNRecs(10).create(), workerFactory));
     }
 }


### PR DESCRIPTION
Multi emitter feature allows multiple producers that read through the given XML file and send out complete records to parsing workers through pipes. This arrangement improves performance significantly.