### PR TITLE
Feature/regularize columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,17 @@ Java: 1.8 and above.
 ```
 ##### Concurrent Workers
 ```java 
+    RecordHandler recordHandler = new DelimitedFileWriter(delimiter, outDir,
+                    recordOutputFieldsDefFile != null || !xsds.isEmpty(),
+                    statusReporter);
     XmlFlattenerWorkerFactory workerFactory = XmlFlattenerWorkerFactory.newInstance(
-                    xmlFilePath, outDir, delimiter, /* Required */
-                    recordTag, xsds, cascadePolicy, recordCascadeFieldsDefFile, recordOutputFieldsDefFile,
-                    batchSize, statusReporter);     /* Required */
+                    recordTag, xsds, cascadePolicy,
+                    recordCascadeFieldsDefFile, recordOutputFieldsDefFile, /* yaml files */
+                    batchSize, statusReporter);
     XmlEventWorkerPool workerPool = new XmlEventWorkerPool();
+    XmlRecordEmitter emitter = new XmlRecordEventEmitter.XmlEventEmitterBuilder()
+                                       .setXmlFile(xmlFilePath)
+                                       .create();
     workerPool.execute(numberOfWorkers, emitter, workerFactory);
 
 ```
@@ -44,23 +50,26 @@ Multiple workers version generates multiple partial files suffixed with _part1, 
 Use the main function in FlattenXmlRunner to run this on command line.
 ```shell script
 usage: FlattenXmlRunner XMLFile [OPTIONS]
- -c,--cascades <arg>        Data for tags under a record(complex) type
-                            element is cascaded to child records.
-                            NONE|ALL|XSD|<record-fields-yaml>.
-                            Defaults to NONE
- -d,--delimiter <arg>       Delimiter. Defaults to a comma(,)
- -f,--output-fields <arg>   Desired output fields for each record(complex)
-                            type in a YAML file
- -n,--n-records <arg>       Number of records to process in the XML
-                            document
- -o,--output-dir <arg>      Output directory for generating tabular files.
-                            Defaults to current directory
- -p,--progress <arg>        Report progress after a batch. Defaults to 100
- -r,--record-tag <arg>      Primary record tag from where parsing begins.
-                            If not provided entire file will be parsed
- -w,--workers <arg>         Number of parallel workers. Defaults to 1
- -x,--xsd <arg>             XSD files. Comma separated list.
-                            Format: emp_ns.xsd,phone_ns.xsd,...
+ -c,--cascades <arg>           Data for tags under a record(complex) type
+                               element is cascaded to child records.
+                               NONE|ALL|XSD|<record-fields-yaml>.
+                               Defaults to NONE
+ -d,--delimiter <arg>          Delimiter. Defaults to a comma(,)
+ -f,--output-fields <arg>      Desired output fields for each record(complex)
+                               type in a YAML file
+ -n,--n-records <int>          Number of records to process in the XML
+                               document
+ -o,--output-dir <arg>         Output directory for generating tabular files.
+                               Defaults to current directory
+ -p,--progress <int>           Report progress after a batch. Defaults to 100
+ -r,--record-tag <arg>         Primary record tag from where parsing begins.
+                               If not provided entire file will be parsed
+ -w,--workers <int>            Number of parallel workers. Defaults to 1
+ -s,--stream-record-strings Y  Distribute XML records as strings to multiple workers.
+                               Less safe but highly performant.
+                               Defaults to streaming records as events
+ -x,--xsd <arg>                XSD files. Comma separated list.
+                               Format: emp_ns.xsd,phone_ns.xsd,...
 ```
 
 #### Output Definition

--- a/src/main/java/com/karbherin/flatterxml/AppConstants.java
+++ b/src/main/java/com/karbherin/flatterxml/AppConstants.java
@@ -1,0 +1,5 @@
+package com.karbherin.flatterxml;
+
+public class AppConstants {
+    public enum CascadePolicy {NONE, ALL, XSD}
+}

--- a/src/main/java/com/karbherin/flatterxml/FlattenXml.java
+++ b/src/main/java/com/karbherin/flatterxml/FlattenXml.java
@@ -99,7 +99,11 @@ public class FlattenXml {
      * @throws IOException
      */
     public long parseFlatten(long firstNRecords) throws XMLStreamException, IOException {
-        return flattenXmlDoc(firstNRecords);
+        long nRecs = flattenXmlDoc(firstNRecords);
+        if (nRecs < firstNRecords) {
+            recordHandler.closeAllFileStreams();
+        }
+        return nRecs;
     }
 
     /**

--- a/src/main/java/com/karbherin/flatterxml/FlattenXml.java
+++ b/src/main/java/com/karbherin/flatterxml/FlattenXml.java
@@ -100,9 +100,6 @@ public class FlattenXml {
      */
     public long parseFlatten(long firstNRecords) throws XMLStreamException, IOException {
         long nRecs = flattenXmlDoc(firstNRecords);
-        if (nRecs < firstNRecords) {
-            recordHandler.closeAllFileStreams();
-        }
         return nRecs;
     }
 

--- a/src/main/java/com/karbherin/flatterxml/FlattenXml.java
+++ b/src/main/java/com/karbherin/flatterxml/FlattenXml.java
@@ -1,5 +1,6 @@
 package com.karbherin.flatterxml;
 
+import com.karbherin.flatterxml.helper.Utils;
 import com.karbherin.flatterxml.helper.XmlHelpers;
 import com.karbherin.flatterxml.model.SchemaElementWithAttributes;
 import com.karbherin.flatterxml.model.Pair;
@@ -140,7 +141,7 @@ public class FlattenXml {
                 } else {
                     rootElementVisited = true;
                     rootElement = el;
-                    iteratorStream((Iterator<Namespace>) rootElement.getNamespaces()).forEach(ns -> {
+                    Utils.iteratorStream(namespacesIterator(rootElement)).forEach(ns -> {
                         xmlnsUriToPrefix.put(ns.getNamespaceURI(), ns);
                     });
                     // The actual record tag string is parsed here as we now have the namespace context
@@ -361,7 +362,7 @@ public class FlattenXml {
             }).collect(Collectors.toList());
         } else {
             // Xml schema not found. Dump all attributes on an element
-            return iteratorStream(attributesIterator(dataElem))
+            return Utils.iteratorStream(attributesIterator(dataElem))
                     .map(attrData -> new Pair<>(
                             String.format(ELEM_ATTR_FMT, elemName, toPrefixedTag(attrData.getName())),
                             attrData.getValue()))
@@ -441,7 +442,7 @@ public class FlattenXml {
                     } else {
 
                         if (prevFv != null) {
-                            numPrevColsAdded = 1 + (int) iteratorStream(attributesIterator(prevFv.getKey())).count();
+                            numPrevColsAdded = 1 + (int) Utils.iteratorStream(attributesIterator(prevFv.getKey())).count();
                         }
 
                         // Clone the record if we have tags repeated

--- a/src/main/java/com/karbherin/flatterxml/FlattenXml.java
+++ b/src/main/java/com/karbherin/flatterxml/FlattenXml.java
@@ -75,6 +75,7 @@ public class FlattenXml {
         this.recordHandler = recordHandler;
         this.xsds.addAll(xsds);
         this.outputRecordFieldsSeq = outputRecordFieldsSeq;
+        recordHandler.setXmlnsUriToPrefix(xmlnsUriToPrefix);
     }
 
     /**
@@ -507,6 +508,10 @@ public class FlattenXml {
 
     public long getBatchRecCounter() {
         return batchRecCounter;
+    }
+
+    public Map<String, Namespace> getXmlnsUriToPrefix() {
+        return xmlnsUriToPrefix;
     }
 
     public static class FlattenXmlBuilder {

--- a/src/main/java/com/karbherin/flatterxml/FlattenXml.java
+++ b/src/main/java/com/karbherin/flatterxml/FlattenXml.java
@@ -10,6 +10,7 @@ import com.karbherin.flatterxml.output.RecordHandler;
 import com.karbherin.flatterxml.xsd.XmlSchema;
 import com.karbherin.flatterxml.xsd.XsdElement;
 
+import static com.karbherin.flatterxml.AppConstants.*;
 import static com.karbherin.flatterxml.helper.XmlHelpers.*;
 
 import javax.xml.namespace.QName;
@@ -32,7 +33,7 @@ public class FlattenXml {
     private QName recordTag = null;  // Will be populated from recordTagGiven
     private final XMLEventReader reader;
     private final List<XmlSchema> xsds = new ArrayList<>();
-    private final RecordFieldsCascade.CascadePolicy cascadePolicy;
+    private final CascadePolicy cascadePolicy;
     private StartElement rootElement;
     private final RecordDefinitions recordCascadesRegistry;
     private final RecordDefinitions outputRecordFieldsSeq;
@@ -61,7 +62,7 @@ public class FlattenXml {
     private final XMLEventFactory eventFactory = XMLEventFactory.newFactory();
 
     private FlattenXml(InputStream xmlStream, String recordTag,
-                       RecordFieldsCascade.CascadePolicy cascadePolicy,
+                       CascadePolicy cascadePolicy,
                        RecordDefinitions recordCascadesRegistry,
                        RecordDefinitions outputRecordFieldsSeq,
                        List<XmlSchema> xsds, RecordHandler recordHandler)
@@ -100,6 +101,9 @@ public class FlattenXml {
      */
     public long parseFlatten(long firstNRecords) throws XMLStreamException, IOException {
         long nRecs = flattenXmlDoc(firstNRecords);
+        if (nRecs < firstNRecords) {
+            recordHandler.closeAllFileStreams();
+        }
         return nRecs;
     }
 
@@ -508,7 +512,7 @@ public class FlattenXml {
     public static class FlattenXmlBuilder {
         private InputStream xmlStream;
         private String recordTag = null;
-        private RecordFieldsCascade.CascadePolicy cascadePolicy = RecordFieldsCascade.CascadePolicy.NONE;
+        private CascadePolicy cascadePolicy = CascadePolicy.NONE;
         private RecordDefinitions recordCascadeFieldsSeq = RecordDefinitions.newInstance();
         private RecordDefinitions recordOutputFieldsSeq = RecordDefinitions.newInstance();
         private List<XmlSchema> xsds = Collections.emptyList();
@@ -524,7 +528,7 @@ public class FlattenXml {
             return this;
         }
 
-        public FlattenXmlBuilder setCascadePolicy(RecordFieldsCascade.CascadePolicy cascadePolicy) {
+        public FlattenXmlBuilder setCascadePolicy(CascadePolicy cascadePolicy) {
             this.cascadePolicy = cascadePolicy;
             return this;
         }

--- a/src/main/java/com/karbherin/flatterxml/FlattenXmlRunner.java
+++ b/src/main/java/com/karbherin/flatterxml/FlattenXmlRunner.java
@@ -7,6 +7,8 @@ import com.karbherin.flatterxml.feeder.XmlEventEmitter;
 import com.karbherin.flatterxml.feeder.XmlRecordEmitter;
 import static com.karbherin.flatterxml.helper.XmlHelpers.*;
 import static com.karbherin.flatterxml.output.RecordHandler.GeneratedResult;
+
+import com.karbherin.flatterxml.helper.Utils;
 import com.karbherin.flatterxml.output.DelimitedFileWriter;
 import com.karbherin.flatterxml.output.RecordHandler;
 import com.karbherin.flatterxml.output.StatusReporter;
@@ -234,7 +236,7 @@ public class FlattenXmlRunner {
             int numProducers = 1;
 
             if (System.getenv(ENV_BYTE_STREAM_MULTI_EMITTER) != null) {
-                int loadFactor = parseInt(System.getenv(ENV_BYTE_STREAM_MULTI_EMITTER), EMITTER_LOAD_FACTOR);
+                int loadFactor = Utils.parseInt(System.getenv(ENV_BYTE_STREAM_MULTI_EMITTER), EMITTER_LOAD_FACTOR);
                 if (numWorkers / loadFactor > 1) {
                     numProducers = numWorkers / loadFactor;
                     System.out.printf("Using %d parallel XML byte stream emitters%n", numProducers);

--- a/src/main/java/com/karbherin/flatterxml/FlattenXmlRunner.java
+++ b/src/main/java/com/karbherin/flatterxml/FlattenXmlRunner.java
@@ -176,7 +176,8 @@ public class FlattenXmlRunner {
         setup.setXmlStream(xmlStream);
 
         // Create XML flattener
-        DelimitedFileWriter recordHandler = new DelimitedFileWriter(delimiter, outDir);
+        DelimitedFileWriter recordHandler = new DelimitedFileWriter(delimiter, outDir,
+                recordOutputFieldsDefFile != null || !xsds.isEmpty());
         setup.setRecordWriter(recordHandler);
         final FlattenXml flattener = setup.create();
 
@@ -223,7 +224,8 @@ public class FlattenXmlRunner {
         InputStream xmlStream = new FileInputStream(xmlFilePath);
         setup.setXmlStream(xmlStream);
 
-        RecordHandler recordHandler = new DelimitedFileWriter(delimiter, outDir);
+        RecordHandler recordHandler = new DelimitedFileWriter(delimiter, outDir,
+                recordOutputFieldsDefFile != null || !xsds.isEmpty());
 
         // Initiate concurrent workers
         XmlRecordEmitter emitter;

--- a/src/main/java/com/karbherin/flatterxml/FlattenXmlRunner.java
+++ b/src/main/java/com/karbherin/flatterxml/FlattenXmlRunner.java
@@ -179,7 +179,8 @@ public class FlattenXmlRunner {
 
         // Create XML flattener
         DelimitedFileWriter recordHandler = new DelimitedFileWriter(delimiter, outDir,
-                recordOutputFieldsDefFile != null || !xsds.isEmpty());
+                recordOutputFieldsDefFile != null || !xsds.isEmpty(),
+                statusReporter);
         setup.setRecordWriter(recordHandler);
         final FlattenXml flattener = setup.create();
 
@@ -227,7 +228,8 @@ public class FlattenXmlRunner {
         setup.setXmlStream(xmlStream);
 
         RecordHandler recordHandler = new DelimitedFileWriter(delimiter, outDir,
-                recordOutputFieldsDefFile != null || !xsds.isEmpty());
+                recordOutputFieldsDefFile != null || !xsds.isEmpty(),
+                statusReporter);
 
         // Initiate concurrent workers
         XmlRecordEmitter emitter;

--- a/src/main/java/com/karbherin/flatterxml/XmlFileSplitterRunner.java
+++ b/src/main/java/com/karbherin/flatterxml/XmlFileSplitterRunner.java
@@ -1,7 +1,6 @@
 package com.karbherin.flatterxml;
 
-import com.karbherin.flatterxml.feeder.XmlByteStreamEmitter;
-import com.karbherin.flatterxml.feeder.XmlEventEmitter;
+import com.karbherin.flatterxml.feeder.XmlRecordStringEmitter;
 import com.karbherin.flatterxml.consumer.XmlEventWorkerPool;
 import com.karbherin.flatterxml.consumer.XmlFileSplitterFactory;
 import org.apache.commons.cli.*;
@@ -59,7 +58,7 @@ public class XmlFileSplitterRunner {
         XmlEventWorkerPool workerPool = new XmlEventWorkerPool();
         XmlFileSplitterFactory workerFactory = XmlFileSplitterFactory.newInstance(outDir, xmlFilePath);
 
-        workerPool.execute(numSplits, new XmlByteStreamEmitter.XmlByteStreamEmitterBuilder()
+        workerPool.execute(numSplits, new XmlRecordStringEmitter.XmlByteStreamEmitterBuilder()
                 .setXmlFile(xmlFilePath).create(), workerFactory);
 
         Long[] recCountsBySplit = workerFactory.getRecordsCount();

--- a/src/main/java/com/karbherin/flatterxml/consumer/XmlFlattenerWorkerFactory.java
+++ b/src/main/java/com/karbherin/flatterxml/consumer/XmlFlattenerWorkerFactory.java
@@ -6,7 +6,7 @@ import com.karbherin.flatterxml.output.StatusReporter;
 import com.karbherin.flatterxml.output.RecordHandler;
 import com.karbherin.flatterxml.xsd.XmlSchema;
 
-import static com.karbherin.flatterxml.model.RecordFieldsCascade.CascadePolicy;
+import static com.karbherin.flatterxml.AppConstants.*;
 
 import java.io.*;
 import java.nio.channels.Channels;
@@ -16,9 +16,6 @@ import java.util.concurrent.CountDownLatch;
 
 public class XmlFlattenerWorkerFactory implements XmlEventWorkerFactory {
 
-    private final String xmlFileName;
-    private final String outDir;
-    private final String delimiter;
     private final String recordTag;
     private final List<XmlSchema> xsds;
     private final CascadePolicy cascadePolicy;
@@ -29,17 +26,13 @@ public class XmlFlattenerWorkerFactory implements XmlEventWorkerFactory {
     private int workerNumber = 0;
     private RecordHandler recordHandler;
 
-    private XmlFlattenerWorkerFactory(String xmlFilePath, String outDir, String delimiter,
-                                      String recordTag, RecordHandler recordHandler,
+    private XmlFlattenerWorkerFactory(String recordTag, RecordHandler recordHandler,
                                       CascadePolicy cascadePolicy,
                                       List<XmlSchema> xsds,
                                       RecordDefinitions recordCascadeFieldsSeq,
                                       RecordDefinitions recordOutputFieldsSeq,
                                       long batchSize, StatusReporter statusReporter) {
 
-        this.xmlFileName = new File(xmlFilePath).getName(); // Extract base name from the XML file path
-        this.outDir = outDir;
-        this.delimiter = delimiter;
         this.recordTag = recordTag;
         this.xsds = xsds;
         this.cascadePolicy = cascadePolicy;
@@ -71,7 +64,7 @@ public class XmlFlattenerWorkerFactory implements XmlEventWorkerFactory {
             recordOutputFieldsSeq = RecordDefinitions.newInstance();
         }
 
-        return new XmlFlattenerWorkerFactory(xmlFilePath, outDir, delimiter, recordTag, recordHandler,
+        return new XmlFlattenerWorkerFactory(recordTag, recordHandler,
                 cascadePolicy, xsds, recordCascadeFieldsSeq, recordOutputFieldsSeq,
                 batchSize, statusReporter);
     }

--- a/src/main/java/com/karbherin/flatterxml/feeder/XmlRecordEventEmitter.java
+++ b/src/main/java/com/karbherin/flatterxml/feeder/XmlRecordEventEmitter.java
@@ -12,7 +12,7 @@ import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.List;
 
-public class XmlEventEmitter implements XmlRecordEmitter {
+public class XmlRecordEventEmitter implements XmlRecordEmitter {
 
     private final XMLOutputFactory outputFactory = XMLOutputFactory.newFactory();
     private final List<XMLEventWriter> channels = new ArrayList<>();
@@ -35,7 +35,7 @@ public class XmlEventEmitter implements XmlRecordEmitter {
      * @throws IOException
      * @throws XMLStreamException
      */
-    private XmlEventEmitter(String xmlFile, long skipRecs, long firstNRecs) {
+    private XmlRecordEventEmitter(String xmlFile, long skipRecs, long firstNRecs) {
         this.xmlFile = xmlFile;
         this.skipRecs = skipRecs;
         this.firstNRecs = firstNRecs;
@@ -204,8 +204,8 @@ public class XmlEventEmitter implements XmlRecordEmitter {
             return this;
         }
 
-        public XmlEventEmitter create() {
-            return new XmlEventEmitter(xmlFile, skipRecs, firstNRecs);
+        public XmlRecordEventEmitter create() {
+            return new XmlRecordEventEmitter(xmlFile, skipRecs, firstNRecs);
         }
     }
 

--- a/src/main/java/com/karbherin/flatterxml/feeder/XmlRecordStringEmitter.java
+++ b/src/main/java/com/karbherin/flatterxml/feeder/XmlRecordStringEmitter.java
@@ -17,11 +17,10 @@ import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.StringJoiner;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicLong;
 
-public class XmlByteStreamEmitter implements XmlRecordEmitter {
+public class XmlRecordStringEmitter implements XmlRecordEmitter {
 
     private final String xmlFile;
     private final Path xmlFilePath;
@@ -47,8 +46,8 @@ public class XmlByteStreamEmitter implements XmlRecordEmitter {
     private static final String END_TAG_FORMAT = "</%s>";
     private static final int ALIGN_WORD_SIZE = 4;
 
-    private XmlByteStreamEmitter(String xmlFile, long skipRecs, long firstNRecs, Charset charset,
-                                int numProducers) throws IOException {
+    private XmlRecordStringEmitter(String xmlFile, long skipRecs, long firstNRecs, Charset charset,
+                                   int numProducers) throws IOException {
         this.xmlFile = xmlFile;
         this.skipRecs = skipRecs;
         this.firstNRecs = firstNRecs;
@@ -403,8 +402,8 @@ public class XmlByteStreamEmitter implements XmlRecordEmitter {
             return this;
         }
 
-        public XmlByteStreamEmitter create() throws IOException {
-            return new XmlByteStreamEmitter(xmlFile, skipRecs, firstNRecs, charset, numProducers);
+        public XmlRecordStringEmitter create() throws IOException {
+            return new XmlRecordStringEmitter(xmlFile, skipRecs, firstNRecs, charset, numProducers);
         }
     }
 

--- a/src/main/java/com/karbherin/flatterxml/feeder/XmlScanner.java
+++ b/src/main/java/com/karbherin/flatterxml/feeder/XmlScanner.java
@@ -11,7 +11,7 @@ import java.nio.channels.WritableByteChannel;
 import java.nio.charset.CharsetDecoder;
 import java.util.List;
 
-public class XmlScanner {
+class XmlScanner {
 
     // Reader
     private final CharsetDecoder decoder;

--- a/src/main/java/com/karbherin/flatterxml/helper/Utils.java
+++ b/src/main/java/com/karbherin/flatterxml/helper/Utils.java
@@ -1,0 +1,88 @@
+package com.karbherin.flatterxml.helper;
+
+import com.karbherin.flatterxml.model.Pair;
+
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+public class Utils {
+    public static<T> Stream<T> iteratorStream(Iterator<T> iterator) {
+        return StreamSupport.stream(
+                Spliterators.spliteratorUnknownSize(iterator, Spliterator.ORDERED), false);
+    }
+
+    public static boolean isEmpty(String str) {
+        return str == null || str.trim().length() == 0;
+    }
+
+    public static <T> T defaultIfNull(T val, T defaultVal) {
+        return val == null ? defaultVal : val;
+    }
+
+    public static String emptyIfNull(String str) {
+        return defaultIfNull(str, XmlHelpers.EMPTY);
+    }
+
+    public static String defaultIfEmpty(String val, String defaultVal) {
+        return val == null ? defaultVal : val;
+    }
+
+    public static int parseInt(String str, int defaultValue) {
+        try {
+            return Integer.valueOf(str);
+        } catch (NumberFormatException ex) {
+            return defaultValue;
+        }
+    }
+
+    public static List<String> collapseSequences(List<String[]> seqs, List<Integer> counts) {
+        List<String> collapsed = new ArrayList<>();
+        Map<String, Map<String, Integer>> successors = new HashMap<>();
+
+        for (int i = 0; i < seqs.size(); i++) {
+            String[] seq = seqs.get(i);
+            String precede = null;
+            for (String successor : seq) {
+                successors.putIfAbsent(precede, new LinkedHashMap<>());
+                Map<String, Integer> nextToken = successors.get(precede);
+
+                nextToken.put(successor, counts.get(i) + nextToken.getOrDefault(successor, 0));
+                precede = successor;
+            }
+        }
+
+        navigateSuccessors(successors, null, collapsed);
+        return collapsed;
+    }
+
+    private static void navigateSuccessors(Map<String, Map<String, Integer>> successors,
+                                                   String startWith,
+                                                   List<String> collapsed) {
+
+        Map<String, Integer> successorsCount = successors.get(startWith);
+        if (successorsCount == null)
+            return;
+
+        List<Map.Entry<String, Integer>> mostFreqSuccessors = new ArrayList<>(successorsCount.entrySet());
+        Collections.sort(mostFreqSuccessors, (a, b) -> b.getValue() - a.getValue());
+
+        for (Map.Entry<String, Integer> successor: mostFreqSuccessors) {
+            int pos = collapsed.lastIndexOf(successor.getKey());
+            if (pos < 0) {
+                collapsed.add(successor.getKey());
+            } else {
+                Map<String, Integer> nextSuccessor = successors.get(successor.getKey());
+                if (nextSuccessor == null ||
+                        nextSuccessor.getOrDefault(startWith, 0) < successor.getValue()) {
+
+                    collapsed.add(collapsed.remove(pos));
+                }
+            }
+
+            if (pos < 0)
+                navigateSuccessors(successors, successor.getKey(), collapsed);
+        }
+    }
+}

--- a/src/main/java/com/karbherin/flatterxml/helper/XmlHelpers.java
+++ b/src/main/java/com/karbherin/flatterxml/helper/XmlHelpers.java
@@ -166,11 +166,6 @@ public class XmlHelpers {
         return null;
     }
 
-    public static<T> Stream<T> iteratorStream(Iterator<T> iterator) {
-        return StreamSupport.stream(
-                Spliterators.spliteratorUnknownSize(iterator, Spliterator.ORDERED), false);
-    }
-
     public static void validateXml(String xmlFile, String xsdFiles[]) throws SAXException, IOException {
         Source[] xsds = new StreamSource[xsdFiles.length];
         Arrays.asList(xsdFiles).stream().map(f -> new StreamSource(f)).collect(Collectors.toList()).toArray(xsds);
@@ -191,30 +186,6 @@ public class XmlHelpers {
 
         XmlSchema.resolveReferences(xsds);
         return xsds;
-    }
-
-    public static boolean isEmpty(String str) {
-        return str == null || str.trim().length() == 0;
-    }
-
-    public static <T> T defaultIfNull(T val, T defaultVal) {
-        return val == null ? defaultVal : val;
-    }
-
-    public static String emptyIfNull(String str) {
-        return defaultIfNull(str, EMPTY);
-    }
-
-    public static String defaultIfEmpty(String val, String defaultVal) {
-        return val == null ? defaultVal : val;
-    }
-
-    public static int parseInt(String str, int defaultValue) {
-        try {
-            return Integer.valueOf(str);
-        } catch (NumberFormatException ex) {
-            return defaultValue;
-        }
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/com/karbherin/flatterxml/model/RecordFieldsCascade.java
+++ b/src/main/java/com/karbherin/flatterxml/model/RecordFieldsCascade.java
@@ -1,6 +1,8 @@
 package com.karbherin.flatterxml.model;
 
 import static com.karbherin.flatterxml.helper.XmlHelpers.*;
+
+import com.karbherin.flatterxml.helper.Utils;
 import com.karbherin.flatterxml.xsd.XmlSchema;
 import com.karbherin.flatterxml.xsd.XsdAttribute;
 
@@ -46,7 +48,7 @@ public final class RecordFieldsCascade implements RecordTypeHierarchy, CascadedA
         Integer pos = positions.get(tagLocalName);
         if (pos != null) {
             Pair<String, String> field = cascadePairList.get(pos);
-            if (!isEmpty(field.getVal())) {
+            if (!Utils.isEmpty(field.getVal())) {
                 return;
             }
             // Capture the data value at the designated location

--- a/src/main/java/com/karbherin/flatterxml/model/RecordFieldsCascade.java
+++ b/src/main/java/com/karbherin/flatterxml/model/RecordFieldsCascade.java
@@ -1,5 +1,6 @@
 package com.karbherin.flatterxml.model;
 
+import static com.karbherin.flatterxml.AppConstants.*;
 import static com.karbherin.flatterxml.helper.XmlHelpers.*;
 
 import com.karbherin.flatterxml.helper.Utils;
@@ -19,8 +20,6 @@ public final class RecordFieldsCascade implements RecordTypeHierarchy, CascadedA
     private final RecordFieldsCascade parent;
     private List<Pair<String, String>> toCascadeToChild = null;
     private final int level;
-
-    public enum CascadePolicy {NONE, ALL, XSD}
 
     public RecordFieldsCascade(StartElement recordName, List<RecordDefinitions.Field> cascadingFields,
                                RecordFieldsCascade parent, List<XmlSchema> xsds) {

--- a/src/main/java/com/karbherin/flatterxml/output/DelimitedFileWriter.java
+++ b/src/main/java/com/karbherin/flatterxml/output/DelimitedFileWriter.java
@@ -9,26 +9,35 @@ import com.karbherin.flatterxml.model.RecordTypeHierarchy;
 import java.io.*;
 import java.nio.ByteBuffer;
 import java.nio.channels.ByteChannel;
+import java.nio.file.CopyOption;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.function.ToIntFunction;
+import java.util.stream.Collectors;
 
 
 public class DelimitedFileWriter implements RecordHandler {
 
-    private final byte[] delimiter;
+    private final String delimiter;
     private final String outDir;
+    // If user does not provide output fields sequence then the fields can vary between records
+    private final boolean outFieldsDefined;
+
     private final List<GeneratedResult> filesWritten = new ArrayList<>();
     private final ConcurrentHashMap<String, ByteChannel> fileStreams = new ConcurrentHashMap<>();
     private final ThreadLocal<ByteBuffer> buffer = ThreadLocal.withInitial(() -> ByteBuffer.allocate(8192));
+    private final ConcurrentHashMap<String, ConcurrentSkipListSet<String>> allRecHeaders = new ConcurrentHashMap<>();
 
     private enum KeyValuePart {FIELD_PART, VALUE_PART}
 
-    public DelimitedFileWriter(String delimiter, String outDir) {
-        this.delimiter = delimiter.getBytes();
+    public DelimitedFileWriter(String delimiter, String outDir, boolean outFieldsDefined) {
+        this.delimiter = delimiter;
         this.outDir = outDir;
+        this.outFieldsDefined = outFieldsDefined;
     }
 
     @Override
@@ -53,10 +62,15 @@ public class DelimitedFileWriter implements RecordHandler {
                 filesWritten.add(new GeneratedResult(currLevel, fName, previousFileName));
 
                 // Writer header record into a newly opened file.
-                writeDelimited(newOut, fieldValueStack, KeyValuePart.FIELD_PART, cascadedData.getCascadedAncestorFields());
+                if (outFieldsDefined) {
+                    writeDelimited(newOut, fieldValueStack, KeyValuePart.FIELD_PART,
+                            cascadedData.getCascadedAncestorFields(), fileName);
+                }
             } catch (IOException ex) {
                 exception.val = ex;
             }
+
+            allRecHeaders.put(fileName, new ConcurrentSkipListSet<>());
 
             return newOut;
         });
@@ -65,11 +79,12 @@ public class DelimitedFileWriter implements RecordHandler {
             throw exception.val;
         }
 
-        writeDelimited(out, fieldValueStack, KeyValuePart.VALUE_PART, cascadedData.getCascadedAncestorFields());
+        writeDelimited(out, fieldValueStack, KeyValuePart.VALUE_PART,
+                cascadedData.getCascadedAncestorFields(), fileName);
     }
 
     @Override
-    public void closeAllFileStreams() {
+    public void closeAllFileStreams() throws IOException {
         for (Map.Entry<String, ByteChannel> entry: fileStreams.entrySet()) {
             ByteChannel out = entry.getValue();
             try {
@@ -77,6 +92,79 @@ public class DelimitedFileWriter implements RecordHandler {
             } catch (IOException ignored) {
             }
         }
+
+        if (!outFieldsDefined) {
+            for (String fileName : fileStreams.keySet()) {
+                realignRecords(allRecHeaders.get(fileName).toArray(new String[0]), fileName);
+            }
+        }
+    }
+
+    private void realignRecords(final String[] headers, String fileName) throws IOException {
+        if (headers.length == 0)
+            return;
+
+        Arrays.sort(headers, Comparator.comparingInt(String::length).reversed());
+        String delimiterRx = String.format("\\%s", String.join("\\", delimiter.split("")));
+        String cleanHeader = headers[0].substring(2, headers[0].length()-1);
+        List<String> allCols = Arrays.asList(
+                cleanHeader.split(delimiterRx));
+
+        Map<String, Integer> colsPos = new HashMap<>();
+        for (int i = 0; i < allCols.size(); i++) {
+            String col = allCols.get(i);
+            colsPos.put(col, i);
+        }
+
+        for (int i = 1; i < headers.length; i++) {
+            String[] cols = headers[i].substring(2, headers[i].length()-1).split(delimiterRx);
+            for (String col : cols) {
+                if (!colsPos.containsKey(col)) {
+                    colsPos.put(col, allCols.size());
+                    allCols.add(col);
+                }
+            }
+        }
+
+
+        String inFileName = String.format("%s/%s.csv", outDir, fileName);
+        String outFileName = String.format("%s/tmp_%s.csv", outDir, fileName);
+        BufferedReader inFile = new BufferedReader(new FileReader(inFileName));
+        BufferedWriter outFile = new BufferedWriter(new FileWriter(outFileName));
+
+        outFile.write(String.join(delimiter, allCols));
+        outFile.write(System.lineSeparator());
+
+        OpenCan<IOException> exception = new OpenCan<>();
+        inFile.lines().forEach(line -> {
+            String[] valuesCols = line.split("\\#");
+            String[] vals = valuesCols[0].split(delimiterRx);
+            String[] cols = valuesCols[1].substring(1, valuesCols[1].length() - 1).split(delimiterRx);
+
+            String[] rec = new String[allCols.size()];
+            for (int i = 0; i < cols.length; i++) {
+                rec[colsPos.get(cols[i])] = vals[i];
+            }
+
+            String record = Arrays.stream(rec).map(field -> field == null ? "" : field)
+                    .collect(Collectors.joining(delimiter));
+            try {
+                outFile.write(record);
+                outFile.write(System.lineSeparator());
+            } catch (IOException ex) {
+                exception.val = ex;
+            }
+        });
+
+        if (exception.val != null) {
+            throw exception.val;
+        }
+
+        outFile.flush();
+        outFile.close();
+
+        Files.deleteIfExists(Paths.get(inFileName));
+        Files.move(Paths.get(outFileName), Paths.get(inFileName));
     }
 
     @Override
@@ -86,42 +174,55 @@ public class DelimitedFileWriter implements RecordHandler {
 
     private void writeDelimited(ByteChannel out,
                                 Iterable<Pair<String, String>> data,
-                                KeyValuePart part, Iterable<Pair<String, String>> appendList)
+                                KeyValuePart part, Iterable<Pair<String, String>> appendList,
+                                String fileName)
             throws IOException {
 
-        Iterator<Pair<String, String>> dataIt = data.iterator();
-        if (!dataIt.hasNext()) {
+        if (!data.iterator().hasNext())
             return;
+
+        StringJoiner colValues = new StringJoiner(delimiter);
+        StringJoiner colNames = new StringJoiner(delimiter, "#[", "]");
+
+        if (part == KeyValuePart.FIELD_PART) {
+            for (Pair<String, String> fv : data) {
+                colValues.add(fv.getKey());
+            }
+
+            // Appendix
+            for (Pair<String, String> fv: appendList) {
+                colValues.add(fv.getKey());
+            }
+
+        } else {
+            for (Pair<String, String> fv : data) {
+                colValues.add(fv.getVal());
+
+                if (!outFieldsDefined) {
+                    colNames.add(fv.getKey());
+                }
+            }
+
+            // Appendix
+            for (Pair<String, String> fv: appendList) {
+                colValues.add(fv.getVal());
+
+                if (!outFieldsDefined) {
+                    colNames.add(fv.getKey());
+                }
+            }
         }
 
         ByteBuffer buf = buffer.get();
         buf.clear();
+        buf.put(colValues.toString().getBytes());
 
-        if (part == KeyValuePart.FIELD_PART) {
-            buf.put(dataIt.next().getKey().getBytes());
-            while (dataIt.hasNext()) {
-                buf.put(delimiter)
-                        .put(dataIt.next().getKey().getBytes());
-            }
-
-            // Appendix
-            for (Pair<String, String> appendData: appendList) {
-                buf.put(delimiter)
-                        .put(appendData.getKey().getBytes());
-            }
-
-        } else {
-            buf.put(dataIt.next().getVal().getBytes());
-            while (dataIt.hasNext()) {
-                buf.put(delimiter)
-                        .put(dataIt.next().getVal().getBytes());
-            }
-
-            // Appendix
-            for (Pair<String, String> appendData: appendList) {
-                buf.put(delimiter)
-                        .put(appendData.getVal().getBytes());
-            }
+        // If user did not provide output fields sequence then the fields can vary between records.
+        // Append the record's header.
+        if (!outFieldsDefined) {
+            String colNamesStr = colNames.toString();
+            buf.put(colNamesStr.getBytes());
+            allRecHeaders.get(fileName).add(colNamesStr);
         }
 
         // Final line separator

--- a/src/main/java/com/karbherin/flatterxml/output/DelimitedFileWriter.java
+++ b/src/main/java/com/karbherin/flatterxml/output/DelimitedFileWriter.java
@@ -113,7 +113,14 @@ public class DelimitedFileWriter implements RecordHandler {
                     + " Regularizing all records to have same sequence of columns");
 
             for (String fileName : fileStreams.keySet()) {
-                realignRecords(allRecHeaders.get(fileName).keySet().toArray(new String[0]), fileName);
+                new Thread(() -> {
+                    try {
+                        realignRecords(allRecHeaders.get(fileName).keySet().toArray(new String[0]), fileName);
+                    } catch (IOException ex) {
+                        statusReporter.logError(
+                                new RuntimeException("Could not post process " + fileName, ex), 1);
+                    }
+                }).start();
             }
 
             long endTime = System.currentTimeMillis();

--- a/src/main/java/com/karbherin/flatterxml/output/DelimitedFileWriter.java
+++ b/src/main/java/com/karbherin/flatterxml/output/DelimitedFileWriter.java
@@ -238,9 +238,10 @@ public class DelimitedFileWriter implements RecordHandler {
         OpenCan<IOException> exception = new OpenCan<>();
         inFile.lines().map(line -> line.split(DATA_HEADER_SEP)).forEach(lineParts -> {
             assert lineParts.length == 2;
-            String[] values = lineParts[0].split(delimiterRx);
             String[] colNames = indexToHeader.get(Integer.parseInt(lineParts[1]));
+            String[] values = lineParts[0].split(delimiterRx, colNames.length);
             assert colNames.length == values.length;
+            assert colNames.length <= allCols.size();
 
             String[] outRec = new String[allCols.size()];
             for (int i = 0, len = colNames.length; i < len; i++) {

--- a/src/main/java/com/karbherin/flatterxml/output/DelimitedFileWriter.java
+++ b/src/main/java/com/karbherin/flatterxml/output/DelimitedFileWriter.java
@@ -1,7 +1,6 @@
 package com.karbherin.flatterxml.output;
 
 import com.karbherin.flatterxml.helper.Utils;
-import com.karbherin.flatterxml.helper.XmlHelpers;
 import com.karbherin.flatterxml.model.CascadedAncestorFields;
 import com.karbherin.flatterxml.model.OpenCan;
 import com.karbherin.flatterxml.model.Pair;
@@ -12,14 +11,14 @@ import java.nio.ByteBuffer;
 import java.nio.channels.ByteChannel;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.nio.file.StandardOpenOption;
 import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import static com.karbherin.flatterxml.helper.XmlHelpers.EMPTY;
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+import static java.nio.file.StandardOpenOption.*;
 
 
 public class DelimitedFileWriter implements RecordHandler {
@@ -70,7 +69,7 @@ public class DelimitedFileWriter implements RecordHandler {
                 String filePath = String.format("%s/%s.csv", outDir, fName);
 
                 newOut = Files.newByteChannel(Paths.get(filePath),
-                        StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE);
+                        CREATE, TRUNCATE_EXISTING, WRITE);
 
                 // Register the new file stream.
                 filesWritten.add(new GeneratedResult(currLevel, fName, previousFileName));
@@ -311,9 +310,9 @@ public class DelimitedFileWriter implements RecordHandler {
 
         outFile.flush();
         outFile.close();
+        inFile.close();
 
-        Files.deleteIfExists(Paths.get(inFileName));
-        Files.move(Paths.get(outFileName), Paths.get(inFileName));
+        Files.move(Paths.get(outFileName), Paths.get(inFileName), REPLACE_EXISTING);
 
         long endTime = System.currentTimeMillis();
         statusReporter.logInfo(String.format("\nRegularized %d records of %s in %d seconds",

--- a/src/main/java/com/karbherin/flatterxml/output/RecordHandler.java
+++ b/src/main/java/com/karbherin/flatterxml/output/RecordHandler.java
@@ -16,7 +16,7 @@ public interface RecordHandler {
 
     List<GeneratedResult> getFilesWritten();
 
-    void closeAllFileStreams();
+    void closeAllFileStreams() throws IOException;
 
 
     final class GeneratedResult {

--- a/src/main/java/com/karbherin/flatterxml/output/RecordHandler.java
+++ b/src/main/java/com/karbherin/flatterxml/output/RecordHandler.java
@@ -5,8 +5,10 @@ import com.karbherin.flatterxml.model.RecordFieldsCascade;
 import com.karbherin.flatterxml.model.Pair;
 import com.karbherin.flatterxml.model.RecordTypeHierarchy;
 
+import javax.xml.stream.events.Namespace;
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 
 public interface RecordHandler {
 
@@ -18,6 +20,7 @@ public interface RecordHandler {
 
     void closeAllFileStreams() throws IOException;
 
+    void setXmlnsUriToPrefix(Map<String, Namespace> xmlnsUriToPrefix);
 
     final class GeneratedResult {
         public final int recordLevel;

--- a/src/main/java/com/karbherin/flatterxml/output/StatusReporter.java
+++ b/src/main/java/com/karbherin/flatterxml/output/StatusReporter.java
@@ -30,6 +30,10 @@ public class StatusReporter {
         exception.printStackTrace(err);
     }
 
+    public synchronized void logError(String message) {
+        err.println(String.format("Error: %s", message));
+    }
+
     public synchronized void logInfo(String message) {
         out.print(message);
     }

--- a/src/main/java/com/karbherin/flatterxml/output/StatusReporter.java
+++ b/src/main/java/com/karbherin/flatterxml/output/StatusReporter.java
@@ -2,6 +2,8 @@ package com.karbherin.flatterxml.output;
 
 import static com.karbherin.flatterxml.output.RecordHandler.GeneratedResult;
 
+import java.io.OutputStream;
+import java.io.PrintStream;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -10,15 +12,26 @@ public class StatusReporter {
 
     private AtomicLong recordCounter = new AtomicLong(0L);
     private Map<String, GeneratedResult> filesGenerated = new HashMap<>();
+    private final PrintStream out;
+    private final PrintStream err;
 
+    public StatusReporter() {
+        out = System.out;
+        err = System.err;
+    }
+
+    public StatusReporter(PrintStream outputStream, PrintStream errorStream) {
+        out = outputStream;
+        err = errorStream;
+    }
 
     public synchronized void logError(Throwable exception, int workerNum) {
-        System.err.println(String.format("\nWorker %d: %s", workerNum, exception.getMessage()));
-        exception.printStackTrace(System.err);
+        err.println(String.format("\nWorker %d: %s", workerNum, exception.getMessage()));
+        exception.printStackTrace(err);
     }
 
     public synchronized void logInfo(String message) {
-        System.out.print(message);
+        out.print(message);
     }
 
     public long incrementRecordCounter(long increment) {

--- a/src/main/java/com/karbherin/flatterxml/xsd/XmlSchema.java
+++ b/src/main/java/com/karbherin/flatterxml/xsd/XmlSchema.java
@@ -1,5 +1,6 @@
 package com.karbherin.flatterxml.xsd;
 
+import com.karbherin.flatterxml.helper.Utils;
 import com.karbherin.flatterxml.model.OpenCan;
 
 import javax.xml.XMLConstants;
@@ -149,7 +150,7 @@ public class XmlSchema {
             String importedSchemaLocation = el.getAttributeByName(SCHEMA_LOCATION).getValue();
             final OpenCan<Throwable> exception = new OpenCan<>();
 
-            iteratorStream((Iterator<Namespace>) schema.getNamespaces())
+            Utils.iteratorStream(namespacesIterator(schema))
                     .filter(ns -> ns.getNamespaceURI().equals(importedNamespace))
                     .findFirst().ifPresent(ns -> {
                 try {

--- a/src/main/java/com/karbherin/flatterxml/xsd/XsdElement.java
+++ b/src/main/java/com/karbherin/flatterxml/xsd/XsdElement.java
@@ -1,5 +1,6 @@
 package com.karbherin.flatterxml.xsd;
 
+import com.karbherin.flatterxml.helper.Utils;
 import com.karbherin.flatterxml.model.SchemaElementWithAttributes;
 
 import static com.karbherin.flatterxml.helper.XmlHelpers.*;
@@ -77,7 +78,7 @@ public class XsdElement implements SchemaElementWithAttributes {
 
     public boolean isList() {
         return UNBOUNDED.equals(maxOccurs)
-                || Integer.parseInt(defaultIfNull(maxOccurs, "1")) > 1;
+                || Integer.parseInt(Utils.defaultIfNull(maxOccurs, "1")) > 1;
     }
 
     @Override

--- a/src/test/java/com/karbherin/flatterxml/FlattenXmlTest.java
+++ b/src/test/java/com/karbherin/flatterxml/FlattenXmlTest.java
@@ -13,7 +13,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static com.karbherin.flatterxml.FlattenXml.FlattenXmlBuilder;
-import static com.karbherin.flatterxml.model.RecordFieldsCascade.CascadePolicy;
+import static com.karbherin.flatterxml.AppConstants.*;
 import static org.junit.Assert.assertEquals;
 
 public class FlattenXmlTest {
@@ -34,7 +34,6 @@ public class FlattenXmlTest {
                 .create();
 
         assertEquals(3, flattener.parseFlatten());
-        recordHandler.closeAllFileStreams();
 
         List<String> employee = fileLines(outDir + "/employee.csv");
         List<String> contact = fileLines(outDir + "/contact.csv");

--- a/src/test/java/com/karbherin/flatterxml/FlattenXmlTest.java
+++ b/src/test/java/com/karbherin/flatterxml/FlattenXmlTest.java
@@ -1,6 +1,7 @@
 package com.karbherin.flatterxml;
 
 import com.karbherin.flatterxml.output.DelimitedFileWriter;
+import com.karbherin.flatterxml.output.RecordHandler;
 import com.karbherin.flatterxml.output.StatusReporter;
 import org.junit.Test;
 
@@ -17,15 +18,18 @@ public class FlattenXmlTest {
 
     @Test
     public void test1() throws IOException, XMLStreamException {
+        RecordHandler recordHandler = new DelimitedFileWriter(
+                "|", "target/test/results/emp_fulldump",
+                false, new StatusReporter());
         FlattenXml flattener = new FlattenXmlBuilder()
                 .setCascadePolicy(CascadePolicy.ALL)
-                .setRecordWriter(new DelimitedFileWriter("|", "target/test/results/emp_fulldump",
-                        false, new StatusReporter()))
+                .setRecordWriter(recordHandler)
                 .setXmlStream(new FileInputStream(
                         new File("src/test/resources/emp_ns.xml")))
                 .create();
 
         assertEquals(3, flattener.parseFlatten());
+        recordHandler.closeAllFileStreams();
 
         List<String> employee = fileLines("target/test/results/emp_fulldump/employee.csv");
         List<String> contact = fileLines("target/test/results/emp_fulldump/contact.csv");
@@ -38,6 +42,7 @@ public class FlattenXmlTest {
         assertEquals(0, addresses.size());
         assertEquals(0, contact.size());
         assertEquals(0, phones.size());
+        assertEquals(5, phone.size());
 
         assertEquals(7, employee.size());
         assertEquals("emp:identifiers|emp:identifiers[emp:id-doc-type]|emp:identifiers[emp:id-doc-expiry]|emp:employee-no|emp:employee-no[emp:status]|emp:employee-name|emp:department|emp:salary",
@@ -55,6 +60,7 @@ public class FlattenXmlTest {
         assertEquals("4567890123|MEDICARE|2021-06-30|00000001|active|Steve Rogers|public relations|150,000.00",
                 employee.get(6));
 
+        // One level nesting
         assertEquals(5, address.size());
         assertEquals("emp:address-type|emp:line1|emp:line2|emp:state|emp:zip" +
                 "|emp:employee.emp:identifiers|emp:employee.emp:identifiers[emp:id-doc-type]|emp:employee.emp:identifiers[emp:id-doc-expiry]|emp:employee.emp:employee-no|emp:employee.emp:employee-no[emp:status]|emp:employee.emp:employee-name|emp:employee.emp:department|emp:employee.emp:salary",
@@ -71,6 +77,35 @@ public class FlattenXmlTest {
         assertEquals("primary|1 Tudor & Place||NY, US|12345" +
                         "|1234567890|SSN||00000001|active|Steve Rogers|public relations|150,000.00",
                 address.get(4));
+
+        // Deeply nested
+        assertEquals(2, reroute.size());
+        assertEquals("Reroute header with cascading. No line2",
+                "emp:employee-name|emp:line1|emp:state|emp:zip" +
+                "|emp:address.emp:address-type|emp:address.emp:line1|emp:address.emp:state|emp:address.emp:zip" +
+                "|emp:employee.emp:identifiers|emp:employee.emp:identifiers[emp:id-doc-type]|emp:employee.emp:identifiers[emp:id-doc-expiry]|emp:employee.emp:employee-no|emp:employee.emp:employee-no[emp:status]|emp:employee.emp:employee-name|emp:employee.emp:department|emp:employee.emp:salary",
+                reroute.get(0));
+        assertEquals("Reroute data. No line2", "Nick Fury|541E Summer St.|NY, US|92478" +
+                        "|primary|1 Tudor & Place|NY, US|12345" +
+                        "|1234567890|SSN|1945-05-25|00000001|active|Steve Rogers|public relations|150,000.00",
+                reroute.get(1));
+
+        // Deeply nested with attributes
+        assertEquals("ph:phone-num|ph:phone-num[ph:contact-type]|ph:phone-type" +
+                "|emp:employee.emp:identifiers|emp:employee.emp:identifiers[emp:id-doc-type]|emp:employee.emp:identifiers[emp:id-doc-expiry]|emp:employee.emp:employee-no|emp:employee.emp:employee-no[emp:status]|emp:employee.emp:employee-name|emp:employee.emp:department|emp:employee.emp:salary",
+                phone.get(0));
+        assertEquals("1234567890|primary|landline" +
+                        "|1234567890|SSN|1945-05-25|00000001|active|Steve Rogers|public relations|150,000.00",
+                phone.get(1));
+        assertEquals("7279237008|primary|cell" +
+                        "|0000000000|SSN||00000002|suspended|Tony Stark|sales|89,000.00",
+                phone.get(2));
+        assertEquals("9090909090|emergency|office" +
+                        "|0000000000|SSN||00000002|suspended|Tony Stark|sales|89,000.00",
+                phone.get(3));
+        assertEquals("1234567890||landline" +
+                        "|1234567890|SSN||00000001|active|Steve Rogers|public relations|150,000.00",
+                phone.get(4));
     }
 
     public List<String> fileLines(String filePath) throws FileNotFoundException {

--- a/src/test/java/com/karbherin/flatterxml/FlattenXmlTest.java
+++ b/src/test/java/com/karbherin/flatterxml/FlattenXmlTest.java
@@ -7,6 +7,8 @@ import org.junit.Test;
 
 import javax.xml.stream.XMLStreamException;
 import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -18,9 +20,12 @@ public class FlattenXmlTest {
 
     @Test
     public void test1() throws IOException, XMLStreamException {
+        String outDir = "target/test/results/emp_fulldump";
+        Files.createDirectories(Paths.get("target/test/results/emp_fulldump"));
         RecordHandler recordHandler = new DelimitedFileWriter(
-                "|", "target/test/results/emp_fulldump",
+                "|", outDir,
                 false, new StatusReporter());
+
         FlattenXml flattener = new FlattenXmlBuilder()
                 .setCascadePolicy(CascadePolicy.ALL)
                 .setRecordWriter(recordHandler)
@@ -31,13 +36,13 @@ public class FlattenXmlTest {
         assertEquals(3, flattener.parseFlatten());
         recordHandler.closeAllFileStreams();
 
-        List<String> employee = fileLines("target/test/results/emp_fulldump/employee.csv");
-        List<String> contact = fileLines("target/test/results/emp_fulldump/contact.csv");
-        List<String> addresses = fileLines("target/test/results/emp_fulldump/addresses.csv");
-        List<String> address = fileLines("target/test/results/emp_fulldump/address.csv");
-        List<String> phones = fileLines("target/test/results/emp_fulldump/phones.csv");
-        List<String> phone = fileLines("target/test/results/emp_fulldump/phone.csv");
-        List<String> reroute = fileLines("target/test/results/emp_fulldump/reroute.csv");
+        List<String> employee = fileLines(outDir + "/employee.csv");
+        List<String> contact = fileLines(outDir + "/contact.csv");
+        List<String> addresses = fileLines(outDir + "/addresses.csv");
+        List<String> address = fileLines(outDir + "/address.csv");
+        List<String> phones = fileLines(outDir + "/phones.csv");
+        List<String> phone = fileLines(outDir + "/phone.csv");
+        List<String> reroute = fileLines(outDir + "/reroute.csv");
 
         assertEquals(0, addresses.size());
         assertEquals(0, contact.size());

--- a/src/test/java/com/karbherin/flatterxml/FlattenXmlTest.java
+++ b/src/test/java/com/karbherin/flatterxml/FlattenXmlTest.java
@@ -1,0 +1,81 @@
+package com.karbherin.flatterxml;
+
+import com.karbherin.flatterxml.output.DelimitedFileWriter;
+import com.karbherin.flatterxml.output.StatusReporter;
+import org.junit.Test;
+
+import javax.xml.stream.XMLStreamException;
+import java.io.*;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.karbherin.flatterxml.FlattenXml.FlattenXmlBuilder;
+import static com.karbherin.flatterxml.model.RecordFieldsCascade.CascadePolicy;
+import static org.junit.Assert.assertEquals;
+
+public class FlattenXmlTest {
+
+    @Test
+    public void test1() throws IOException, XMLStreamException {
+        FlattenXml flattener = new FlattenXmlBuilder()
+                .setCascadePolicy(CascadePolicy.ALL)
+                .setRecordWriter(new DelimitedFileWriter("|", "target/test/results/emp_fulldump",
+                        false, new StatusReporter()))
+                .setXmlStream(new FileInputStream(
+                        new File("src/test/resources/emp_ns.xml")))
+                .create();
+
+        assertEquals(3, flattener.parseFlatten());
+
+        List<String> employee = fileLines("target/test/results/emp_fulldump/employee.csv");
+        List<String> contact = fileLines("target/test/results/emp_fulldump/contact.csv");
+        List<String> addresses = fileLines("target/test/results/emp_fulldump/addresses.csv");
+        List<String> address = fileLines("target/test/results/emp_fulldump/address.csv");
+        List<String> phones = fileLines("target/test/results/emp_fulldump/phones.csv");
+        List<String> phone = fileLines("target/test/results/emp_fulldump/phone.csv");
+        List<String> reroute = fileLines("target/test/results/emp_fulldump/reroute.csv");
+
+        assertEquals(0, addresses.size());
+        assertEquals(0, contact.size());
+        assertEquals(0, phones.size());
+
+        assertEquals(7, employee.size());
+        assertEquals("emp:identifiers|emp:identifiers[emp:id-doc-type]|emp:identifiers[emp:id-doc-expiry]|emp:employee-no|emp:employee-no[emp:status]|emp:employee-name|emp:department|emp:salary",
+                employee.get(0));
+        assertEquals("1234567890|SSN|1945-05-25|00000001|active|Steve Rogers|public relations|150,000.00",
+                employee.get(1));
+        assertEquals("4567890123|MEDICARE|2021-06-30|00000001|active|Steve Rogers|public relations|150,000.00",
+                employee.get(2));
+        assertEquals("0000000000|SSN||00000002|suspended|Tony Stark|sales|89,000.00",
+                employee.get(3));
+        assertEquals("8908907890|MIT|2008-12-28|00000002|suspended|Tony Stark|sales|89,000.00",
+                employee.get(4));
+        assertEquals("1234567890|SSN||00000001|active|Steve Rogers|public relations|150,000.00",
+                employee.get(5));
+        assertEquals("4567890123|MEDICARE|2021-06-30|00000001|active|Steve Rogers|public relations|150,000.00",
+                employee.get(6));
+
+        assertEquals(5, address.size());
+        assertEquals("emp:address-type|emp:line1|emp:line2|emp:state|emp:zip" +
+                "|emp:employee.emp:identifiers|emp:employee.emp:identifiers[emp:id-doc-type]|emp:employee.emp:identifiers[emp:id-doc-expiry]|emp:employee.emp:employee-no|emp:employee.emp:employee-no[emp:status]|emp:employee.emp:employee-name|emp:employee.emp:department|emp:employee.emp:salary",
+                address.get(0));
+        assertEquals("primary|1 Tudor & Place||NY, US|12345" +
+                "|1234567890|SSN|1945-05-25|00000001|active|Steve Rogers|public relations|150,000.00",
+                address.get(1));
+        assertEquals("primary|1 Bloomington St|Suite 3000|DC, US|22344" +
+                        "|0000000000|SSN||00000002|suspended|Tony Stark|sales|89,000.00",
+                address.get(2));
+        assertEquals("holiday|19 Wilmington View||NC, US|27617" +
+                        "|0000000000|SSN||00000002|suspended|Tony Stark|sales|89,000.00",
+                address.get(3));
+        assertEquals("primary|1 Tudor & Place||NY, US|12345" +
+                        "|1234567890|SSN||00000001|active|Steve Rogers|public relations|150,000.00",
+                address.get(4));
+    }
+
+    public List<String> fileLines(String filePath) throws FileNotFoundException {
+        return new BufferedReader(new FileReader(new File(filePath)))
+                .lines().collect(Collectors.toList());
+    }
+
+}

--- a/src/test/java/com/karbherin/flatterxml/feeder/XmlFileSplitterTest.java
+++ b/src/test/java/com/karbherin/flatterxml/feeder/XmlFileSplitterTest.java
@@ -18,19 +18,19 @@ public class XmlFileSplitterTest {
         XmlFileSplitterFactory workerFactory = XmlFileSplitterFactory.newInstance(outDir, xmlFilePath);
 
         Assert.assertEquals("Entire file", 21,
-                workerPool.execute(3, new XmlEventEmitter.XmlEventEmitterBuilder()
+                workerPool.execute(3, new XmlRecordEventEmitter.XmlEventEmitterBuilder()
                         .setXmlFile(xmlFilePath).create(), workerFactory));
         Assert.assertEquals("Skip 5 records", 16,
-                workerPool.execute(3, new XmlEventEmitter.XmlEventEmitterBuilder()
+                workerPool.execute(3, new XmlRecordEventEmitter.XmlEventEmitterBuilder()
                         .setXmlFile(xmlFilePath).setSkipRecs(5).create(), workerFactory));
         Assert.assertEquals("Skip 5 and pick first 4", 4,
-                workerPool.execute(3, new XmlEventEmitter.XmlEventEmitterBuilder()
+                workerPool.execute(3, new XmlRecordEventEmitter.XmlEventEmitterBuilder()
                         .setXmlFile(xmlFilePath).setSkipRecs(5).setFirstNRecs(4).create(), workerFactory));
         Assert.assertEquals("First 4 records", 4,
-                workerPool.execute(3, new XmlEventEmitter.XmlEventEmitterBuilder()
+                workerPool.execute(3, new XmlRecordEventEmitter.XmlEventEmitterBuilder()
                         .setXmlFile(xmlFilePath).setSkipRecs(0).setFirstNRecs(4).create(), workerFactory));
         Assert.assertEquals("Overshoot the end", 3,
-                workerPool.execute(3, new XmlEventEmitter.XmlEventEmitterBuilder()
+                workerPool.execute(3, new XmlRecordEventEmitter.XmlEventEmitterBuilder()
                         .setXmlFile(xmlFilePath).setSkipRecs(18).setFirstNRecs(10).create(), workerFactory));
     }
 
@@ -42,19 +42,19 @@ public class XmlFileSplitterTest {
         XmlFileSplitterFactory workerFactory = XmlFileSplitterFactory.newInstance(outDir, xmlFilePath);
 
         Assert.assertEquals("Entire file", 21,
-                workerPool.execute(3, new XmlByteStreamEmitter.XmlByteStreamEmitterBuilder()
+                workerPool.execute(3, new XmlRecordStringEmitter.XmlByteStreamEmitterBuilder()
                         .setXmlFile(xmlFilePath).create(), workerFactory));
         Assert.assertEquals("Skip 5 records", 16,
-                workerPool.execute(3, new XmlByteStreamEmitter.XmlByteStreamEmitterBuilder()
+                workerPool.execute(3, new XmlRecordStringEmitter.XmlByteStreamEmitterBuilder()
                         .setXmlFile(xmlFilePath).setSkipRecs(5).create(), workerFactory));
         Assert.assertEquals("Skip 5 and pick first 4", 4,
-                workerPool.execute(3, new XmlByteStreamEmitter.XmlByteStreamEmitterBuilder()
+                workerPool.execute(3, new XmlRecordStringEmitter.XmlByteStreamEmitterBuilder()
                         .setXmlFile(xmlFilePath).setSkipRecs(5).setFirstNRecs(4).create(), workerFactory));
         Assert.assertEquals("First 4 records", 4,
-                workerPool.execute(3, new XmlByteStreamEmitter.XmlByteStreamEmitterBuilder()
+                workerPool.execute(3, new XmlRecordStringEmitter.XmlByteStreamEmitterBuilder()
                         .setXmlFile(xmlFilePath).setSkipRecs(0).setFirstNRecs(4).create(), workerFactory));
         Assert.assertEquals("Overshoot the end", 3,
-                workerPool.execute(3, new XmlByteStreamEmitter.XmlByteStreamEmitterBuilder()
+                workerPool.execute(3, new XmlRecordStringEmitter.XmlByteStreamEmitterBuilder()
                         .setXmlFile(xmlFilePath).setSkipRecs(18).setFirstNRecs(10).create(), workerFactory));
     }
 }

--- a/src/test/java/com/karbherin/flatterxml/feeder/XmlRecordEventEmitterTest.java
+++ b/src/test/java/com/karbherin/flatterxml/feeder/XmlRecordEventEmitterTest.java
@@ -9,28 +9,28 @@ import java.nio.channels.Channels;
 import java.nio.channels.Pipe;
 import java.util.concurrent.CountDownLatch;
 
-public class XmlEventEmitterTest {
+public class XmlRecordEventEmitterTest {
 
     @Test
     public void test() throws IOException, XMLStreamException, InterruptedException {
         String xmlFile = "src/test/resources/emp.xml";
         Assert.assertEquals("Entire file", 21, run(
-                new XmlEventEmitter.XmlEventEmitterBuilder()
+                new XmlRecordEventEmitter.XmlEventEmitterBuilder()
                 .setXmlFile(xmlFile).create()));
         Assert.assertEquals("Skip 5 records", 16, run(
-                new XmlEventEmitter.XmlEventEmitterBuilder()
+                new XmlRecordEventEmitter.XmlEventEmitterBuilder()
                 .setXmlFile(xmlFile).setSkipRecs(5).create()));
         Assert.assertEquals("Skip 5 and pick first 4", 4, run(
-                new XmlEventEmitter.XmlEventEmitterBuilder()
+                new XmlRecordEventEmitter.XmlEventEmitterBuilder()
                 .setXmlFile(xmlFile).setSkipRecs(5).setFirstNRecs(4).create()));
         Assert.assertEquals("First 4 records", 4, run(
-                new XmlEventEmitter.XmlEventEmitterBuilder()
+                new XmlRecordEventEmitter.XmlEventEmitterBuilder()
                 .setXmlFile(xmlFile).setSkipRecs(0).setFirstNRecs(4).create()));
         Assert.assertEquals("Overshoot the end", 3, run(
-                new XmlEventEmitter.XmlEventEmitterBuilder()
+                new XmlRecordEventEmitter.XmlEventEmitterBuilder()
                 .setXmlFile(xmlFile).setSkipRecs(18).setFirstNRecs(10).create()));
     }
-    private long run(XmlEventEmitter emitter)
+    private long run(XmlRecordEventEmitter emitter)
             throws IOException, XMLStreamException, InterruptedException {
 
         int numWorkers = 3;

--- a/src/test/java/com/karbherin/flatterxml/feeder/XmlRecordStringEmitterTest.java
+++ b/src/test/java/com/karbherin/flatterxml/feeder/XmlRecordStringEmitterTest.java
@@ -5,7 +5,7 @@ import static org.junit.Assert.assertEquals;
 import com.karbherin.flatterxml.consumer.XmlEventWorkerFactory;
 import com.karbherin.flatterxml.consumer.XmlEventWorkerPool;
 import com.karbherin.flatterxml.consumer.XmlFileSplitterFactory;
-import static com.karbherin.flatterxml.feeder.XmlByteStreamEmitter.XmlByteStreamEmitterBuilder;
+import static com.karbherin.flatterxml.feeder.XmlRecordStringEmitter.XmlByteStreamEmitterBuilder;
 
 import com.karbherin.flatterxml.helper.XmlHelpers;
 import org.junit.Test;
@@ -21,10 +21,10 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.concurrent.CountDownLatch;
 
-public class XmlByteStreamEmitterTest {
+public class XmlRecordStringEmitterTest {
     /*@Test
     public void test() throws IOException, XMLStreamException {
-        XmlByteStreamEmitter emitter = new XmlByteStreamEmitterBuilder()
+        XmlRecordStringEmitter emitter = new XmlByteStreamEmitterBuilder()
                 .setXmlFile("src/test/resources/emp_ns.xml")
                 .setSkipRecs(0)
                 .setFirstNRecs(0)
@@ -53,18 +53,18 @@ public class XmlByteStreamEmitterTest {
                 workerPool.execute(1, new XmlByteStreamEmitterBuilder().setXmlFile(xmlFilePath).create(),
                         new XmlPipeToFileWriter(outDir, "emp_bytestream.xml")));
         assertEquals("Skip 5 records", 16,
-                workerPool.execute(3, new XmlByteStreamEmitter.XmlByteStreamEmitterBuilder().setXmlFile(xmlFilePath)
+                workerPool.execute(3, new XmlRecordStringEmitter.XmlByteStreamEmitterBuilder().setXmlFile(xmlFilePath)
                         .setSkipRecs(5).create(), workerFactory));
         assertEquals("Skip 5 records", 16,
-                workerPool.execute(3, new XmlByteStreamEmitter.XmlByteStreamEmitterBuilder().setXmlFile(xmlFilePath)
+                workerPool.execute(3, new XmlRecordStringEmitter.XmlByteStreamEmitterBuilder().setXmlFile(xmlFilePath)
                         .setSkipRecs(5).create(), workerFactory));
         assertEquals("Skip 5 and pick first 4", 4,
-                workerPool.execute(3, new XmlByteStreamEmitter.XmlByteStreamEmitterBuilder().setXmlFile(xmlFilePath)
+                workerPool.execute(3, new XmlRecordStringEmitter.XmlByteStreamEmitterBuilder().setXmlFile(xmlFilePath)
                         .setSkipRecs(5).setFirstNRecs(4).create(), workerFactory));
         assertEquals("First 4 records", 4,
-                workerPool.execute(3, new XmlByteStreamEmitter.XmlByteStreamEmitterBuilder().setXmlFile(xmlFilePath)
+                workerPool.execute(3, new XmlRecordStringEmitter.XmlByteStreamEmitterBuilder().setXmlFile(xmlFilePath)
                         .setSkipRecs(0).setFirstNRecs(4).create(), workerFactory));
-        XmlRecordEmitter emitter = new XmlByteStreamEmitter.XmlByteStreamEmitterBuilder().setXmlFile(xmlFilePath)
+        XmlRecordEmitter emitter = new XmlRecordStringEmitter.XmlByteStreamEmitterBuilder().setXmlFile(xmlFilePath)
                 .setSkipRecs(18).setFirstNRecs(10).create();
         assertEquals("Overshoot the end", 3,
                 workerPool.execute(3, emitter, workerFactory));
@@ -77,7 +77,7 @@ public class XmlByteStreamEmitterTest {
     public void splitterNSXml_test() throws IOException, XMLStreamException, InterruptedException {
         String xmlFilePath = "src/test/resources/emp.xml";
         String outDir = "target/test/results/emp_bytestream_splits";
-        XmlRecordEmitter emitter = new XmlByteStreamEmitter.XmlByteStreamEmitterBuilder()
+        XmlRecordEmitter emitter = new XmlRecordStringEmitter.XmlByteStreamEmitterBuilder()
                 .setXmlFile("src/test/resources/emp_ns.xml").setSkipRecs(1).setFirstNRecs(10).create();
         XmlFileSplitterFactory workerFactory = XmlFileSplitterFactory.newInstance(outDir, xmlFilePath);
         XmlEventWorkerPool workerPool = new XmlEventWorkerPool();

--- a/src/test/java/com/karbherin/flatterxml/helper/ParserHelpersTest.java
+++ b/src/test/java/com/karbherin/flatterxml/helper/ParserHelpersTest.java
@@ -5,6 +5,9 @@ import static org.junit.Assert.*;
 import com.karbherin.flatterxml.model.Pair;
 import org.junit.Test;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import static com.karbherin.flatterxml.helper.ParsingHelpers.*;
 public class ParserHelpersTest {
 
@@ -42,5 +45,21 @@ public class ParserHelpersTest {
         assertEquals("\"3\" : \"5\"", coord.toString());
     }
 
+    @Test
+    public void testElemAttr() {
+        Pattern elemAttrRx = Pattern.compile("^(?<elem>.*?)(\\[(?<attr>.*?)?\\])?$");
+        Matcher mat = elemAttrRx.matcher("ph:phone-num");
+        assertTrue(mat.find());
+        if (mat.find()) {
+            assertEquals("ph:phone-num", mat.group("elem"));
+            assertNull(mat.group("attr"));
+        }
 
+        mat = elemAttrRx.matcher("ph:phone-num[ph:contact-type]");
+        assertTrue(mat.find());
+        if (mat.find()) {
+            assertEquals("ph:phone-num", mat.group("elem"));
+            assertEquals("ph:contact-type", mat.group("attr"));
+        }
+    }
 }

--- a/src/test/java/com/karbherin/flatterxml/helper/UtilsTest.java
+++ b/src/test/java/com/karbherin/flatterxml/helper/UtilsTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import java.util.*;
 
 import static com.karbherin.flatterxml.helper.Utils.collapseSequences;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
 public class UtilsTest {
@@ -110,15 +111,37 @@ public class UtilsTest {
         assertEquals("Testing against cycles in the graph",
                 "col1,col2,col3,col5,col4", String.join(",", collapseSequences(seqs, counts)));
 
+        // Flip order of last two sequences
         seqs.add(seqs.remove(1));
         assertEquals("Testing against cycles in the graph but elements reversed",
                 "col1,col2,col3,col4,col5", String.join(",", collapseSequences(seqs, counts)));
     }
 
     @Test
-    public void testSplit() {
-        String[] parts = "someval1|someval2##HEADER>#somekey1|somekey2".split("##HEADER>#");
-        assertEquals("someval1|someval2", parts[0]);
-        assertEquals("somekey1|somekey2", parts[1]);
+    public void testCollapseSequences5() {
+        List<String[]> seqs = new ArrayList<>();
+        List<Integer> counts = new ArrayList<>();
+        seqs.add(new String[] {"emp:identifiers","emp:identifiers[emp:id-doc-type]","emp:identifiers[emp:id-doc-expiry]","emp:employee-no","emp:employee-no[emp:status]","emp:employee-name","emp:department","emp:salary"});
+        seqs.add(new String[] {"emp:identifiers","emp:identifiers[emp:id-doc-type]","emp:employee-no","emp:employee-no[emp:status]","emp:employee-name","emp:department","emp:salary"});
+        counts.add(1);
+        counts.add(1);
+        assertEquals(
+                "emp:identifiers,emp:identifiers[emp:id-doc-type],emp:identifiers[emp:id-doc-expiry],emp:employee-no,emp:employee-no[emp:status],emp:employee-name,emp:department,emp:salary",
+                String.join(",", collapseSequences(seqs, counts)));
+    }
+
+    @Test
+    public void testCollapseSequences6() {
+        List<String[]> seqs = new ArrayList<>();
+        List<Integer> counts = new ArrayList<>();
+        seqs.add("emp:address-type|emp:line1|emp:line2|emp:state|emp:zip|emp:employee.emp:identifiers|emp:employee.emp:identifiers[emp:id-doc-type]|emp:employee.emp:identifiers[emp:id-doc-expiry]|emp:employee.emp:employee-no|emp:employee.emp:employee-no[emp:status]|emp:employee.emp:employee-name|emp:employee.emp:department|emp:employee.emp:salary"
+                .split("\\|"));
+        seqs.add("emp:address-type|emp:line1|emp:state|emp:zip|emp:employee.emp:identifiers|emp:employee.emp:identifiers[emp:id-doc-type]|emp:employee.emp:identifiers[emp:id-doc-expiry]|emp:employee.emp:employee-no|emp:employee.emp:employee-no[emp:status]|emp:employee.emp:employee-name|emp:employee.emp:department|emp:employee.emp:salary"
+                .split("\\|"));
+        counts.add(2);
+        counts.add(2);
+        assertEquals("emp:address-type|emp:line1|emp:line2|emp:state|emp:zip" +
+                        "|emp:employee.emp:identifiers|emp:employee.emp:identifiers[emp:id-doc-type]|emp:employee.emp:identifiers[emp:id-doc-expiry]|emp:employee.emp:employee-no|emp:employee.emp:employee-no[emp:status]|emp:employee.emp:employee-name|emp:employee.emp:department|emp:employee.emp:salary",
+                String.join("|", collapseSequences(seqs, counts)));
     }
 }

--- a/src/test/java/com/karbherin/flatterxml/helper/UtilsTest.java
+++ b/src/test/java/com/karbherin/flatterxml/helper/UtilsTest.java
@@ -1,0 +1,124 @@
+package com.karbherin.flatterxml.helper;
+
+import org.junit.Test;
+
+import java.util.*;
+
+import static com.karbherin.flatterxml.helper.Utils.collapseSequences;
+import static org.junit.Assert.assertEquals;
+
+public class UtilsTest {
+
+    @Test
+    public void testCollapseSequences1() {
+
+        List<String[]> seqs = new ArrayList<>();
+        List<Integer> counts = new ArrayList<>();
+        seqs.add(new String[] {"col1", "col2", "col4"});
+        counts.add(3);
+        seqs.add(new String[] {"col1", "col2", "col3"});
+        counts.add(2);
+        seqs.add(new String[] {"col1", "col2", "col5"});
+        counts.add(2);
+        assertEquals("After col2, col4 is most frequent and, col3 and col5 are equally likely",
+                "col1,col2,col4,col3,col5", String.join(",", collapseSequences(seqs, counts)));
+
+        seqs = new ArrayList<>();
+        counts = new ArrayList<>();
+        seqs.add(new String[] {"col1", "col2", "col4"});
+        counts.add(3);
+        seqs.add(new String[] {"col1", "col2", "col5"});
+        counts.add(2);
+        seqs.add(new String[] {"col1", "col2", "col3"});
+        counts.add(2);
+        assertEquals("Col3 and col5 swap places but continue as equally likely",
+                "col1,col2,col4,col5,col3", String.join(",", collapseSequences(seqs, counts)));
+
+        seqs.add(seqs.remove(1));
+        assertEquals("col1,col2,col4,col3,col5", String.join(",", collapseSequences(seqs, counts)));
+    }
+
+    @Test
+    public void testCollapseSequences2() {
+        List<String[]> seqs = new ArrayList<>();
+        List<Integer> counts = new ArrayList<>();
+        seqs.add(new String[] {"col1", "col2", "col4"});
+        counts.add(3);
+        seqs.add(new String[] {"col1", "col2", "col3"});
+        counts.add(2);
+        seqs.add(new String[] {"col1", "col2", "col5"});
+        counts.add(2);
+        seqs.add(new String[] {"col1", "col2", "col5", "col4"});
+        counts.add(2);
+        assertEquals("When col5 is present it occurs before col4",
+                "col1,col2,col5,col4,col3", String.join(",", collapseSequences(seqs, counts)));
+
+        seqs = new ArrayList<>();
+        counts = new ArrayList<>();
+        seqs.add(new String[] {"col1", "col2", "col4"});
+        counts.add(3);
+        seqs.add(new String[] {"col1", "col2", "col3"});
+        counts.add(2);
+        seqs.add(new String[] {"col1", "col2", "col5"});
+        counts.add(2);
+        seqs.add(new String[] {"col1", "col2", "col5", "col4"});
+        counts.add(1);
+        assertEquals("When col5 is present it occurs before col4 even though col5 only ever appears once",
+                "col1,col2,col5,col4,col3", String.join(",", collapseSequences(seqs, counts)));
+
+        seqs = new ArrayList<>();
+        counts = new ArrayList<>();
+        seqs.add(new String[] {"col1", "col2", "col4"});
+        counts.add(4);
+        seqs.add(new String[] {"col1", "col2", "col3"});
+        counts.add(2);
+        seqs.add(new String[] {"col1", "col2", "col5"});
+        counts.add(2);
+        seqs.add(new String[] {"col1", "col2", "col5", "col4"});
+        counts.add(1);
+        assertEquals("When col5 is present it occurs before col4 even if col4 follows col2 more frequently",
+                "col1,col2,col5,col4,col3", String.join(",", collapseSequences(seqs, counts)));
+    }
+
+    @Test
+    public void testCollapseSequences3() {
+        List<String[]> seqs = new ArrayList<>();
+        List<Integer> counts = new ArrayList<>();
+        seqs.add(new String[] {"col1", "col2", "col3", "col4"});
+        counts.add(3);
+        seqs.add(new String[] {"col1", "col2", "col4"});
+        counts.add(2);
+        seqs.add(new String[] {"col1", "col2", "col5"});
+        counts.add(2);
+        seqs.add(new String[] {"col1", "col2", "col4", "col5"});
+        counts.add(2);
+        seqs.add(new String[] {"col1", "col2", "col3", "col4", "col5"});
+        counts.add(3);
+        assertEquals("col1,col2,col3,col4,col5", String.join(",", collapseSequences(seqs, counts)));
+    }
+
+    @Test
+    public void testCollapseSequences4() {
+        List<String[]> seqs = new ArrayList<>();
+        List<Integer> counts = new ArrayList<>();
+        seqs.add(new String[] {"col1", "col2", "col3", "col4"});
+        counts.add(2);
+        seqs.add(new String[] {"col1", "col2", "col5", "col4"});
+        counts.add(2);
+        seqs.add(new String[] {"col1", "col2", "col4", "col5"});
+        counts.add(2);
+        assertEquals("Testing against cycles in the graph",
+                "col1,col2,col3,col5,col4", String.join(",", collapseSequences(seqs, counts)));
+
+        seqs.add(seqs.remove(1));
+        assertEquals("Testing against cycles in the graph but elements reversed",
+                "col1,col2,col3,col4,col5", String.join(",", collapseSequences(seqs, counts)));
+    }
+
+    @Test
+    public void testSplit() {
+        String[] parts = "someval1|someval2##HEADER>#somekey1|somekey2".split("##HEADER>#");
+        assertEquals("someval1|someval2", parts[0]);
+        assertEquals("somekey1|somekey2", parts[1]);
+    }
+}

--- a/src/test/java/com/karbherin/flatterxml/output/DelimitedFileWriterTest.java
+++ b/src/test/java/com/karbherin/flatterxml/output/DelimitedFileWriterTest.java
@@ -1,0 +1,15 @@
+package com.karbherin.flatterxml.output;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class DelimitedFileWriterTest {
+
+    @Test
+    public void testSplit() {
+        String[] parts = "someval1|someval2##HEADER>#somekey1|somekey2".split("##HEADER>#");
+        assertEquals("someval1|someval2", parts[0]);
+        assertEquals("somekey1|somekey2", parts[1]);
+    }
+}

--- a/src/test/java/com/karbherin/flatterxml/xsd/XmlSchemaNSTest.java
+++ b/src/test/java/com/karbherin/flatterxml/xsd/XmlSchemaNSTest.java
@@ -10,11 +10,10 @@ import javax.xml.stream.XMLEventFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.events.Namespace;
 import java.io.FileNotFoundException;
-import java.util.Iterator;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static com.karbherin.flatterxml.helper.XmlHelpers.iteratorStream;
+import static com.karbherin.flatterxml.helper.Utils.iteratorStream;
 import static com.karbherin.flatterxml.helper.XmlHelpers.namespacesIterator;
 import static org.junit.Assert.*;
 

--- a/src/test/java/com/karbherin/flatterxml/xsd/XmlSchemaTest.java
+++ b/src/test/java/com/karbherin/flatterxml/xsd/XmlSchemaTest.java
@@ -3,7 +3,7 @@ package com.karbherin.flatterxml.xsd;
 import static com.karbherin.flatterxml.helper.XmlHelpers.namespacesIterator;
 import static org.junit.Assert.*;
 
-import static com.karbherin.flatterxml.helper.XmlHelpers.iteratorStream;
+import static com.karbherin.flatterxml.helper.Utils.iteratorStream;
 
 import com.karbherin.flatterxml.helper.XmlHelpers;
 import org.junit.BeforeClass;


### PR DESCRIPTION
When user does not specify XSD or output record definitions each record in a tabular file can have varied sequences of columns. Regularizing all the records to contain the same number and sequence of columns makes the output useful to consumption.
Produce a output record definitions file that outlines the structure of the resulting tables.
The generated output record definitions file can be used in subsequent processing of XML files which speeds up processing and produces tables with a defined sequence of columns. 