### PR TITLE
Replace newlines in data of XML elements with given character to -l

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ usage: FlattenXmlRunner XMLFile [OPTIONS]
                                NONE|ALL|XSD|<record-fields-yaml>.
                                Defaults to NONE
  -d,--delimiter <arg>          Delimiter. Defaults to a comma(,)
+ -l,--newline <arg>            Newline replacement character. Defaults to tilde(~)
  -f,--output-fields <arg>      Desired output fields for each record(complex)
                                type in a YAML file
  -n,--n-records <int>          Number of records to process in the XML

--- a/src/test/resources/emp.xml
+++ b/src/test/resources/emp.xml
@@ -16,7 +16,8 @@
           <zip>12345</zip>
           <reroute>  <!-- reroute.csv: While cascading, deepest info is presented first: <reroute-fields>|<address-fields>|<employee-fields> [deepest first]-->
             <employee-name>Nick Fury</employee-name>
-            <line1>541E Summer St.</line1>
+            <line1>541E
+              Summer St.</line1>
             <!-- While cascading with "XSD" policy "line2" field with empty value is printed, despite the element missing here. Always intend to use "XSD" policy -->
             <!-- But when cascading with "ALL" policy "line2" field will be missing in the output. "ALL" works only if XML file includes all the fields for complex types -->
             <state>NY, US</state>


### PR DESCRIPTION
Allow user to specify a character for replacing newlines in data of an XML element.
A new option -l is added to the CLI class.
Enhance DelimitedFileWriter's constructor to read the newline replacement character.
Default to '~' when user does not specify it.